### PR TITLE
B-U585I-IOT02A_BSP 

### DIFF
--- a/Keil.B-U585I-IOT02A_BSP.pdsc
+++ b/Keil.B-U585I-IOT02A_BSP.pdsc
@@ -8,6 +8,11 @@
   <license>LICENSE</license>
 
   <releases>
+    <release version="1.1.0-dev4">
+      Example projects:
+      - Update VIO to API 1.0.0
+      - Synchronize to CMSIS 6.0.0
+    </release>
     <release version="1.1.0-dev3">
       Synchronized with STM32CubeU5 Firmware Package version V1.2.0
     </release>
@@ -414,7 +419,7 @@
     </bundle>
 
     <!-- CMSIS VIO Driver component for B-U585I-IOT02A -->
-    <component Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant= "B-U585I-IOT02A" Cversion="1.2.0" Capiversion="0.1.0" condition="B-U585I-IOT02A VIO">
+    <component Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant= "B-U585I-IOT02A" Cversion="2.0.0" Capiversion="1.0.0" condition="B-U585I-IOT02A VIO">
       <description>Virtual I/O implementation for B-U585I-IOT02A</description>
       <RTE_Components_h>
         #define RTE_VIO_BOARD

--- a/Projects/Blinky/Blinky.uvoptx
+++ b/Projects/Blinky/Blinky.uvoptx
@@ -155,18 +155,18 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-View\1.1.0\EventRecorder\EventRecorder.scvd</Filename>
+        <Type>ARM::CMSIS-View@1.1.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\ARM_Compiler\1.7.2\EventRecorder.scvd</Filename>
-        <Type>Keil.ARM_Compiler.1.7.2</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -318,6 +318,14 @@
   </Group>
 
   <Group>
+    <GroupName>::CMSIS-View</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>1</RteFlg>
+  </Group>
+
+  <Group>
     <GroupName>::Board Support</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
@@ -335,14 +343,6 @@
 
   <Group>
     <GroupName>::CMSIS Driver</GroupName>
-    <tvExp>0</tvExp>
-    <tvExpOptDlg>0</tvExpOptDlg>
-    <cbSel>0</cbSel>
-    <RteFlg>1</RteFlg>
-  </Group>
-
-  <Group>
-    <GroupName>::Compiler</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/Projects/Blinky/Blinky.uvprojx
+++ b/Projects/Blinky/Blinky.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>B-U585I-IOT02A</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ESEL ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -427,6 +427,9 @@
           </Files>
         </Group>
         <Group>
+          <GroupName>::CMSIS-View</GroupName>
+        </Group>
+        <Group>
           <GroupName>::Board Support</GroupName>
         </Group>
         <Group>
@@ -434,9 +437,6 @@
         </Group>
         <Group>
           <GroupName>::CMSIS Driver</GroupName>
-        </Group>
-        <Group>
-          <GroupName>::Compiler</GroupName>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -447,7 +447,7 @@
 
   <RTE>
     <gpdscs>
-      <gpdsc name=".\Board\B-U585I-IOT02A\STM32CubeMX\FrameworkCubeMX.gpdsc">
+      <gpdsc name="Board/B-U585I-IOT02A/STM32CubeMX/FrameworkCubeMX.gpdsc">
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
@@ -455,289 +455,303 @@
     </gpdscs>
     <boards>
       <board Bname="B-U585I-IOT02A" Bvendor="STMicroelectronics" Bversion="Rev.C">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </board>
     </boards>
     <apis>
-      <api Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="5.7.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
-      <api Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="5.6.0"/>
+      <api Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="Device" Cgroup="STM32Cube Framework" condition="STM32U5" exclusive="1">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.2" url="https://www.keil.com/pack/" vendor="Keil" version="2.0.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
     </apis>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder">
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.1"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="6.0.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device" isTargetSpecific="1">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Cvendor="ARM" Cversion="1.0.5" condition="OS Tick SysTick">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
-          <targetInfo name="B-U585I-IOT02A">
-            <mem>
-              <RVCTZI>1</RVCTZI>
-            </mem>
-          </targetInfo>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </component>
+      <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5">
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="IIS2MDC" Cvendor="Keil" Cversion="1.1.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="ISM330DHCX" Cvendor="Keil" Cversion="1.1.3" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="BUS" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP BUS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Motion Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP MOTION SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="1.2.0" condition="B-U585I-IOT02A VIO">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="2.0.0" condition="B-U585I-IOT02A VIO">
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube Framework" Csub="STM32CubeMX" Cvendor="Keil" Cversion="2.0.0" condition="STCubeMX" doc="C:/PACK/Keil/STM32U5xx_DFP/2.2.0/MDK/CubeMX/Documentation/cubemx.html" generated="1" generator="STM32CubeMX" selectable="1">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA DLYB">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA DLYB">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL GPIO Flash">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL GPIO Flash">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SRAM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SRAM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
     </components>
     <files>
-      <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.1.0">
+      <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\b_u585i_iot02a_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="CMSIS\RTOS2\RTX\Config\RTX_Config.c" version="5.1.1">
+      <file attr="config" category="header" name="EventRecorder\Config\EventRecorderConf.h" version="1.1.0">
+        <instance index="0">RTE\CMSIS-View\EventRecorderConf.h</instance>
+        <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder"/>
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.1.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </file>
+      <file attr="config" category="source" name="Config\RTX_Config.c" version="5.2.0">
         <instance index="0">RTE\CMSIS\RTX_Config.c</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="CMSIS\RTOS2\RTX\Config\RTX_Config.h" version="5.5.2">
+      <file attr="config" category="header" name="Config\RTX_Config.h" version="5.6.0">
         <instance index="0">RTE\CMSIS\RTX_Config.h</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
-        <targetInfos>
-          <targetInfo name="B-U585I-IOT02A"/>
-        </targetInfos>
-      </file>
-      <file attr="config" category="header" name="Config\EventRecorderConf.h" version="1.1.0">
-        <instance index="0">RTE\Compiler\EventRecorderConf.h</instance>
-        <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device"/>
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
       <file attr="config" category="source" condition="STM32U585 ARMCC" name="MDK\Device\Source\arm\startup_stm32u585xx.s" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\startup_stm32u585xx.s</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
       <file attr="config" category="linkerScript" condition="STM32U585 noTZ ARMCC" name="MDK\Device\Source\arm\linker\stm32u585xx_flash.sct" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\stm32u585xx_flash.sct</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.2.0">
+      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.3.0">
         <instance index="0">RTE\Device\STM32U585AIIx\system_stm32u5xx.c</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>

--- a/Projects/Blinky/RTE/CMSIS-View/EventRecorderConf.h
+++ b/Projects/Blinky/RTE/CMSIS-View/EventRecorderConf.h
@@ -1,11 +1,24 @@
-/*------------------------------------------------------------------------------
- * MDK - Component ::Event Recorder
- * Copyright (c) 2016-2018 ARM Germany GmbH. All rights reserved.
- *------------------------------------------------------------------------------
+/*
+ * Copyright (c) 2016-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Name:    EventRecorderConf.h
- * Purpose: Event Recorder Configuration
+ * Purpose: Event Recorder software component configuration options
  * Rev.:    V1.1.0
- *----------------------------------------------------------------------------*/
+ */
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 

--- a/Projects/Blinky/RTE/CMSIS/RTX_Config.c
+++ b/Projects/Blinky/RTE/CMSIS/RTX_Config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.1
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration
@@ -54,6 +54,9 @@ __WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
       break;
     case osRtxErrorClibMutex:
       // Standard C/C++ library mutex initialization failed
+      break;
+    case osRtxErrorSVC:
+      // Invalid SVC function called (function=object_id)
       break;
     default:
       // Reserved

--- a/Projects/Blinky/RTE/CMSIS/RTX_Config.h
+++ b/Projects/Blinky/RTE/CMSIS/RTX_Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.5.2
+ * $Revision:   V5.6.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -146,6 +146,20 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID    0
 #endif
  
+//   <o>Idle Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_CLASS
+#define OS_IDLE_THREAD_CLASS        0
+#endif
+ 
+//   <o>Idle Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_ZONE
+#define OS_IDLE_THREAD_ZONE         0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enables stack overrun check at thread switch (requires RTX source variant).
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -160,10 +174,10 @@
 #define OS_STACK_WATERMARK          0
 #endif
  
-//   <o>Processor mode for Thread execution
+//   <o>Default Processor mode for Thread execution
 //     <0=> Unprivileged mode
 //     <1=> Privileged mode
-//   <i> Default: Privileged mode
+//   <i> Default: Unprivileged mode
 #ifndef OS_PRIVILEGE_MODE
 #define OS_PRIVILEGE_MODE           1
 #endif
@@ -213,6 +227,20 @@
 //   <i> Default: 0 (not used)
 #ifndef OS_TIMER_THREAD_TZ_MOD_ID
 #define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_CLASS
+#define OS_TIMER_THREAD_CLASS       0
+#endif
+ 
+//   <o>Timer Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_ZONE
+#define OS_TIMER_THREAD_ZONE        0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>

--- a/Projects/Middleware/USB/Device/HID/Abstract.txt
+++ b/Projects/Middleware/USB/Device/HID/Abstract.txt
@@ -20,12 +20,10 @@ The program is available in different targets:
 
  - Debug:
    - Compiler:                  ARM Compiler optimization Level 1
-   - Compiler:Event Recorder:   Enabled
-   - CMSIS:RTOS2:Keil RTX5:     Source
+   - CMSIS-View:Event Recorder: Enabled
    - USB:CORE:                  Debug
 
  - Release:
    - Compiler:                  ARM Compiler optimization Level 3
-   - Compiler:Event Recorder:   Disabled
-   - CMSIS:RTOS2:Keil RTX5:     Library
+   - CMSIS-View:Event Recorder: Disabled
    - USB:CORE:                  Release

--- a/Projects/Middleware/USB/Device/HID/HID.uvoptx
+++ b/Projects/Middleware/USB/Device/HID/HID.uvoptx
@@ -155,23 +155,23 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\ARM_Compiler\1.7.2\EventRecorder.scvd</Filename>
-        <Type>Keil.ARM_Compiler.1.7.2</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-View\1.1.0\EventRecorder\EventRecorder.scvd</Filename>
+        <Type>ARM::CMSIS-View@1.1.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -363,18 +363,18 @@
         </Mm>
       </MemoryWindow1>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -562,7 +562,7 @@
   </Group>
 
   <Group>
-    <GroupName>::Compiler</GroupName>
+    <GroupName>::CMSIS-View</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/Projects/Middleware/USB/Device/HID/HID.uvprojx
+++ b/Projects/Middleware/USB/Device/HID/HID.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>Debug</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -329,7 +329,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -441,7 +441,7 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-View</GroupName>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -455,13 +455,13 @@
       <TargetName>Release</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -621,7 +621,7 @@
             <GenPPlst>0</GenPPlst>
             <AdsCpuType>"Cortex-M33"</AdsCpuType>
             <RvctDeviceName></RvctDeviceName>
-            <mOS>1</mOS>
+            <mOS>0</mOS>
             <uocRom>0</uocRom>
             <uocRam>0</uocRam>
             <hadIROM>1</hadIROM>
@@ -774,7 +774,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -886,7 +886,7 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-View</GroupName>
           <GroupOption>
             <CommonProperty>
               <UseCPPCompiler>0</UseCPPCompiler>
@@ -978,7 +978,7 @@
     </gpdscs>
     <boards>
       <board Bname="B-U585I-IOT02A" Brevision="Rev.C" Bvendor="STMicroelectronics" Bversion="Rev.C">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -987,49 +987,56 @@
     </boards>
     <apis>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="SPI" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.4.0" Cclass="CMSIS Driver" Cgroup="USART" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="Device" Cgroup="STM32Cube Framework" condition="STM32U5" exclusive="1">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.2" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1037,357 +1044,363 @@
       </api>
     </apis>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder" isTargetSpecific="1">
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.1"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="6.0.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Cvendor="ARM" Cversion="1.0.5" condition="OS Tick SysTick">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
+          <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5" isTargetSpecific="1">
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device" isTargetSpecific="1">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug">
-            <mem>
-              <RVCTZI>1</RVCTZI>
-            </mem>
-          </targetInfo>
+          <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="IIS2MDC" Cvendor="Keil" Cversion="1.1.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="ISM330DHCX" Cvendor="Keil" Cversion="1.1.3" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="TCPP0203" Cvendor="Keil" Cversion="1.2.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="BUS" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP BUS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Motion Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP MOTION SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="USB PD" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP USB PD">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Driver and Class Instance" maxInstances="4">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="HID" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Instance and Device Driver" maxInstances="4">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="SPI" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver SPI">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS_Driver USART">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.0.0" condition="STM32U5 CMSIS_Driver USBD">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver USBD">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="1.2.0" condition="B-U585I-IOT02A VIO">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="2.0.0" condition="B-U585I-IOT02A VIO">
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube Framework" Csub="STM32CubeMX" Cvendor="Keil" Cversion="2.0.0" condition="STCubeMX" doc="C:/PACK/Keil/STM32U5xx_DFP/2.2.0/MDK/CubeMX/Documentation/cubemx.html" generated="1" generator="STM32CubeMX" selectable="1">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA DLYB">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA DLYB">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL GPIO Flash">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL GPIO Flash">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="HID" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Instance and Device Driver" maxInstances="8">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Driver and Class Instance" maxInstances="4">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1398,7 +1411,7 @@
       <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\b_u585i_iot02a_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1407,25 +1420,34 @@
       <file attr="config" category="header" name="Drivers\Config\mx_wifi_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\mx_wifi_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="CMSIS\RTOS2\RTX\Config\RTX_Config.c" version="5.1.1">
+      <file attr="config" category="header" name="EventRecorder\Config\EventRecorderConf.h" version="1.1.0">
+        <instance index="0">RTE\CMSIS-View\EventRecorderConf.h</instance>
+        <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder"/>
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.1.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </file>
+      <file attr="config" category="source" name="Config\RTX_Config.c" version="5.2.0">
         <instance index="0">RTE\CMSIS\RTX_Config.c</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="CMSIS\RTOS2\RTX\Config\RTX_Config.h" version="5.5.2">
+      <file attr="config" category="header" name="Config\RTX_Config.h" version="5.6.0">
         <instance index="0">RTE\CMSIS\RTX_Config.h</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1434,24 +1456,16 @@
       <file attr="config" category="header" name="CMSIS\Driver\Config\WiFi_EMW3080_Config.h" version="1.0.0">
         <instance index="0">RTE\CMSIS_Driver\STM32U585AIIx\WiFi_EMW3080_Config.h</instance>
         <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="Config\EventRecorderConf.h" version="1.1.0">
-        <instance index="0">RTE\Compiler\EventRecorderConf.h</instance>
-        <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device"/>
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </file>
       <file attr="config" category="source" condition="STM32U585 ARMCC" name="MDK\Device\Source\arm\startup_stm32u585xx.s" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\startup_stm32u585xx.s</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1459,35 +1473,35 @@
       </file>
       <file attr="config" category="linkerScript" condition="STM32U585 noTZ ARMCC" name="MDK\Device\Source\arm\linker\stm32u585xx_flash.sct" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\stm32u585xx_flash.sct</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.2.0">
+      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.3.0">
         <instance index="0">RTE\Device\STM32U585AIIx\system_stm32u5xx.c</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="USB\Config\USBD_Config.c" version="5.2.0">
+      <file attr="config" category="source" name="USB\Config\USBD_Config.c" version="5.3.0">
         <instance index="0">RTE\USB\USBD_Config_0.c</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Driver and Class Instance" maxInstances="4"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Driver and Class Instance" maxInstances="4"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="USB\Config\USBD_Config_HID.h" version="5.0.2">
+      <file attr="config" category="header" name="USB\Config\USBD_Config_HID.h" version="5.1.0">
         <instance index="0">RTE\USB\USBD_Config_HID_0.h</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="HID" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Instance and Device Driver" maxInstances="4"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="HID" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Instance and Device Driver" maxInstances="8"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1495,8 +1509,8 @@
       </file>
       <file attr="config" category="source" name="USB\Config\USB_Debug.c" version="1.0.0">
         <instance index="0">RTE\USB\USB_Debug.c</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
         </targetInfos>

--- a/Projects/Middleware/USB/Device/HID/RTE/CMSIS-View/EventRecorderConf.h
+++ b/Projects/Middleware/USB/Device/HID/RTE/CMSIS-View/EventRecorderConf.h
@@ -1,11 +1,24 @@
-/*------------------------------------------------------------------------------
- * MDK - Component ::Event Recorder
- * Copyright (c) 2016-2018 ARM Germany GmbH. All rights reserved.
- *------------------------------------------------------------------------------
+/*
+ * Copyright (c) 2016-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Name:    EventRecorderConf.h
- * Purpose: Event Recorder Configuration
+ * Purpose: Event Recorder software component configuration options
  * Rev.:    V1.1.0
- *----------------------------------------------------------------------------*/
+ */
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 

--- a/Projects/Middleware/USB/Device/HID/RTE/CMSIS/RTX_Config.c
+++ b/Projects/Middleware/USB/Device/HID/RTE/CMSIS/RTX_Config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.1
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration
@@ -54,6 +54,9 @@ __WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
       break;
     case osRtxErrorClibMutex:
       // Standard C/C++ library mutex initialization failed
+      break;
+    case osRtxErrorSVC:
+      // Invalid SVC function called (function=object_id)
       break;
     default:
       // Reserved

--- a/Projects/Middleware/USB/Device/HID/RTE/CMSIS/RTX_Config.h
+++ b/Projects/Middleware/USB/Device/HID/RTE/CMSIS/RTX_Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.5.2
+ * $Revision:   V5.6.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -69,6 +69,61 @@
 //     <i> Default: 5
 #ifndef OS_ROBIN_TIMEOUT
 #define OS_ROBIN_TIMEOUT            5
+#endif
+ 
+//   </e>
+ 
+//   <e>Safety features (Source variant only)
+//   <i> Enables FuSa related features.
+//   <i> Requires RTX Source variant.
+//   <i> Enables:
+//   <i>  - selected features from this group
+//   <i>  - Thread functions: osThreadProtectPrivileged
+#ifndef OS_SAFETY_FEATURES
+#define OS_SAFETY_FEATURES          0
+#endif
+ 
+//     <q>Safety Class
+//     <i> Threads assigned to lower classes cannot modify higher class threads.
+//     <i> Enables:
+//     <i>  - Object attributes: osSafetyClass
+//     <i>  - Kernel functions: osKernelProtect, osKernelDestroyClass
+//     <i>  - Thread functions: osThreadGetClass, osThreadSuspendClass, osThreadResumeClass
+#ifndef OS_SAFETY_CLASS
+#define OS_SAFETY_CLASS             1
+#endif
+ 
+//     <q>MPU Protected Zone
+//     <i> Access protection via MPU (Spatial isolation).
+//     <i> Enables:
+//     <i>  - Thread attributes: osThreadZone
+//     <i>  - Thread functions: osThreadGetZone, osThreadTerminateZone
+//     <i>  - Zone Management: osZoneSetup_Callback
+#ifndef OS_EXECUTION_ZONE
+#define OS_EXECUTION_ZONE           1
+#endif
+ 
+//     <q>Thread Watchdog
+//     <i> Watchdog alerts ensure timing for critical threads (Temporal isolation).
+//     <i> Enables:
+//     <i>  - Thread functions: osThreadFeedWatchdog
+//     <i>  - Handler functions: osWatchdogAlarm_Handler
+#ifndef OS_THREAD_WATCHDOG
+#define OS_THREAD_WATCHDOG          1
+#endif
+ 
+//     <q>Object Pointer checking
+//     <i> Check object pointer alignment and memory region.
+#ifndef OS_OBJ_PTR_CHECK
+#define OS_OBJ_PTR_CHECK            0
+#endif
+ 
+//     <q>SVC Function Pointer checking
+//     <i> Check SVC function pointer alignment and memory region.
+//     <i> User needs to define a linker execution region RTX_SVC_VENEERS
+//     <i> containing input sections: rtx_*.o (.text.os.svc.veneer.*)
+#ifndef OS_SVC_PTR_CHECK
+#define OS_SVC_PTR_CHECK            0
 #endif
  
 //   </e>
@@ -146,6 +201,20 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID    0
 #endif
  
+//   <o>Idle Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_CLASS
+#define OS_IDLE_THREAD_CLASS        0
+#endif
+ 
+//   <o>Idle Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_ZONE
+#define OS_IDLE_THREAD_ZONE         0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enables stack overrun check at thread switch (requires RTX source variant).
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -160,10 +229,10 @@
 #define OS_STACK_WATERMARK          0
 #endif
  
-//   <o>Processor mode for Thread execution
+//   <o>Default Processor mode for Thread execution
 //     <0=> Unprivileged mode
 //     <1=> Privileged mode
-//   <i> Default: Privileged mode
+//   <i> Default: Unprivileged mode
 #ifndef OS_PRIVILEGE_MODE
 #define OS_PRIVILEGE_MODE           1
 #endif
@@ -213,6 +282,20 @@
 //   <i> Default: 0 (not used)
 #ifndef OS_TIMER_THREAD_TZ_MOD_ID
 #define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_CLASS
+#define OS_TIMER_THREAD_CLASS       0
+#endif
+ 
+//   <o>Timer Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_ZONE
+#define OS_TIMER_THREAD_ZONE        0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>

--- a/Projects/Middleware/USB/Device/HID/RTE/USB/USBD_Config_0.c
+++ b/Projects/Middleware/USB/Device/HID/RTE/USB/USBD_Config_0.c
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBD_Config_0.c
  * Purpose: USB Device Configuration
- * Rev.:    V5.2.0
+ * Rev.:    V5.3.0
  *------------------------------------------------------------------------------
  * Use the following configuration settings in the Device Class configuration
  * files to assign a Device Class to this USB Device 0.
@@ -71,11 +71,11 @@
 
 //     <s.126>Manufacturer String
 //     <i>String Descriptor describing Manufacturer.
-#define USBD0_STR_DESC_MAN              L"Keil Software"
+#define USBD0_STR_DESC_MAN_RAW          "Keil Software"
 
 //     <s.126>Product String
 //     <i>String Descriptor describing Product.
-#define USBD0_STR_DESC_PROD             L"Keil USB Device 0"
+#define USBD0_STR_DESC_PROD_RAW         "Keil USB Device 0"
 
 //     <e.0>Serial Number String
 //     <i>Enable Serial Number String.
@@ -84,7 +84,7 @@
 
 //       <s.126>Default value
 //       <i>Default device's Serial Number String.
-#define USBD0_STR_DESC_SER              L"0001A0000000"
+#define USBD0_STR_DESC_SER_RAW          "0001A0000000"
 
 //       <o.0..7>Maximum Length (in characters) <0-126>
 //       <i>Specifies the maximum number of Serial Number String characters that can be set at run-time.
@@ -123,84 +123,5 @@
 //   </h>
 // </h>
 
-
-#include "RTE_Components.h"
-
-#ifdef  RTE_USB_Device_CustomClass_0
-#include "USBD_Config_CustomClass_0.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_1
-#include "USBD_Config_CustomClass_1.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_2
-#include "USBD_Config_CustomClass_2.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_3
-#include "USBD_Config_CustomClass_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_HID_0
-#include "USBD_Config_HID_0.h"
-#endif
-#ifdef  RTE_USB_Device_HID_1
-#include "USBD_Config_HID_1.h"
-#endif
-#ifdef  RTE_USB_Device_HID_2
-#include "USBD_Config_HID_2.h"
-#endif
-#ifdef  RTE_USB_Device_HID_3
-#include "USBD_Config_HID_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_MSC_0
-#include "USBD_Config_MSC_0.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_1
-#include "USBD_Config_MSC_1.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_2
-#include "USBD_Config_MSC_2.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_3
-#include "USBD_Config_MSC_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_CDC_0
-#include "USBD_Config_CDC_0.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_1
-#include "USBD_Config_CDC_1.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_2
-#include "USBD_Config_CDC_2.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_3
-#include "USBD_Config_CDC_3.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_4
-#include "USBD_Config_CDC_4.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_5
-#include "USBD_Config_CDC_5.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_6
-#include "USBD_Config_CDC_6.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_7
-#include "USBD_Config_CDC_7.h"
-#endif
-
-#ifdef  RTE_USB_Device_ADC_0
-#include "USBD_Config_ADC_0.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_1
-#include "USBD_Config_ADC_1.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_2
-#include "USBD_Config_ADC_2.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_3
-#include "USBD_Config_ADC_3.h"
-#endif
 
 #include "usbd_config.h"

--- a/Projects/Middleware/USB/Device/HID/RTE/USB/USBD_Config_HID_0.h
+++ b/Projects/Middleware/USB/Device/HID/RTE/USB/USBD_Config_HID_0.h
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2020 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBD_Config_HID_0.h
  * Purpose: USB Device Human Interface Device class (HID) Configuration
- * Rev.:    V5.0.2
+ * Rev.:    V5.1.0
  *----------------------------------------------------------------------------*/
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
@@ -119,7 +119,7 @@
 //   <i>and for memory allocation in the USB component.
 //
 //     <s.126>HID Interface String
-#define USBD_HID0_STR_DESC                        L"USB_HID0"
+#define USBD_HID0_STR_DESC_RAW                    "USB_HID0"
 
 //     <o.0..4>Number of Input Reports <1-32>
 //     <i>Configures max 'rid' value for USBD_HID0_GetReport and USBD_HID_GetReportTrigger

--- a/Projects/Middleware/USB/Device/MassStorage/Abstract.txt
+++ b/Projects/Middleware/USB/Device/MassStorage/Abstract.txt
@@ -15,12 +15,10 @@ The program is available in different targets:
 
  - Debug:
    - Compiler:                  ARM Compiler optimization Level 1
-   - Compiler:Event Recorder:   Enabled
-   - CMSIS:RTOS2:Keil RTX5:     Source
+   - CMSIS-View:Event Recorder: Enabled
    - USB:CORE:                  Debug
 
  - Release:
    - Compiler:                  ARM Compiler optimization Level 3
-   - Compiler:Event Recorder:   Disabled
-   - CMSIS:RTOS2:Keil RTX5:     Library
+   - CMSIS-View:Event Recorder: Disabled
    - USB:CORE:                  Release

--- a/Projects/Middleware/USB/Device/MassStorage/MassStorage.uvoptx
+++ b/Projects/Middleware/USB/Device/MassStorage/MassStorage.uvoptx
@@ -155,23 +155,23 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\ARM_Compiler\1.7.2\EventRecorder.scvd</Filename>
-        <Type>Keil.ARM_Compiler.1.7.2</Type>
+        <Filename>C:\PACK\ARM\CMSIS-View\1.1.0\EventRecorder\EventRecorder.scvd</Filename>
+        <Type>ARM::CMSIS-View@1.1.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -355,13 +355,18 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
+        <SubType>1</SubType>
+      </ScvdPack>
+      <ScvdPack>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -561,7 +566,7 @@
   </Group>
 
   <Group>
-    <GroupName>::Compiler</GroupName>
+    <GroupName>::CMSIS-View</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/Projects/Middleware/USB/Device/MassStorage/MassStorage.uvprojx
+++ b/Projects/Middleware/USB/Device/MassStorage/MassStorage.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>Debug</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -329,7 +329,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -446,7 +446,7 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-View</GroupName>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -460,13 +460,13 @@
       <TargetName>Release</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -779,7 +779,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -896,7 +896,7 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-View</GroupName>
           <GroupOption>
             <CommonProperty>
               <UseCPPCompiler>0</UseCPPCompiler>
@@ -988,7 +988,7 @@
     </gpdscs>
     <boards>
       <board Bname="B-U585I-IOT02A" Brevision="Rev.C" Bvendor="STMicroelectronics" Bversion="Rev.C">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -997,49 +997,56 @@
     </boards>
     <apis>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="SPI" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.4.0" Cclass="CMSIS Driver" Cgroup="USART" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="Device" Cgroup="STM32Cube Framework" condition="STM32U5" exclusive="1">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.2" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1047,357 +1054,363 @@
       </api>
     </apis>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder" isTargetSpecific="1">
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.1"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="6.0.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Cvendor="ARM" Cversion="1.0.5" condition="OS Tick SysTick">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
+          <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5" isTargetSpecific="1">
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device" isTargetSpecific="1">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug">
-            <mem>
-              <RVCTZI>1</RVCTZI>
-            </mem>
-          </targetInfo>
+          <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="IIS2MDC" Cvendor="Keil" Cversion="1.1.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="ISM330DHCX" Cvendor="Keil" Cversion="1.1.3" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="TCPP0203" Cvendor="Keil" Cversion="1.2.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="BUS" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP BUS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Motion Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP MOTION SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="USB PD" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP USB PD">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Driver and Class Instance" maxInstances="4">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="MSC" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Instance and Device Driver" maxInstances="4">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="SPI" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver SPI">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS_Driver USART">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.0.0" condition="STM32U5 CMSIS_Driver USBD">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver USBD">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="1.2.0" condition="B-U585I-IOT02A VIO">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="2.0.0" condition="B-U585I-IOT02A VIO">
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube Framework" Csub="STM32CubeMX" Cvendor="Keil" Cversion="2.0.0" condition="STCubeMX" doc="C:/PACK/Keil/STM32U5xx_DFP/2.2.0/MDK/CubeMX/Documentation/cubemx.html" generated="1" generator="STM32CubeMX" selectable="1">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA DLYB">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA DLYB">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL GPIO Flash">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL GPIO Flash">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="MSC" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Instance and Device Driver" maxInstances="4">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Driver and Class Instance" maxInstances="4">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1408,7 +1421,7 @@
       <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\b_u585i_iot02a_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1417,25 +1430,34 @@
       <file attr="config" category="header" name="Drivers\Config\mx_wifi_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\mx_wifi_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="CMSIS\RTOS2\RTX\Config\RTX_Config.c" version="5.1.1">
+      <file attr="config" category="header" name="EventRecorder\Config\EventRecorderConf.h" version="1.1.0">
+        <instance index="0">RTE\CMSIS-View\EventRecorderConf.h</instance>
+        <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder"/>
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.1.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </file>
+      <file attr="config" category="source" name="Config\RTX_Config.c" version="5.2.0">
         <instance index="0">RTE\CMSIS\RTX_Config.c</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="CMSIS\RTOS2\RTX\Config\RTX_Config.h" version="5.5.2">
+      <file attr="config" category="header" name="Config\RTX_Config.h" version="5.6.0">
         <instance index="0">RTE\CMSIS\RTX_Config.h</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1444,24 +1466,16 @@
       <file attr="config" category="header" name="CMSIS\Driver\Config\WiFi_EMW3080_Config.h" version="1.0.0">
         <instance index="0">RTE\CMSIS_Driver\STM32U585AIIx\WiFi_EMW3080_Config.h</instance>
         <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="Config\EventRecorderConf.h" version="1.1.0">
-        <instance index="0">RTE\Compiler\EventRecorderConf.h</instance>
-        <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device"/>
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </file>
       <file attr="config" category="source" condition="STM32U585 ARMCC" name="MDK\Device\Source\arm\startup_stm32u585xx.s" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\startup_stm32u585xx.s</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1469,35 +1483,35 @@
       </file>
       <file attr="config" category="linkerScript" condition="STM32U585 noTZ ARMCC" name="MDK\Device\Source\arm\linker\stm32u585xx_flash.sct" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\stm32u585xx_flash.sct</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.2.0">
+      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.3.0">
         <instance index="0">RTE\Device\STM32U585AIIx\system_stm32u5xx.c</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="USB\Config\USBD_Config.c" version="5.2.0">
+      <file attr="config" category="source" name="USB\Config\USBD_Config.c" version="5.3.0">
         <instance index="0">RTE\USB\USBD_Config_0.c</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Driver and Class Instance" maxInstances="4"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Driver and Class Instance" maxInstances="4"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="USB\Config\USBD_Config_MSC.h" version="5.1.1">
+      <file attr="config" category="header" name="USB\Config\USBD_Config_MSC.h" version="5.2.0">
         <instance index="0">RTE\USB\USBD_Config_MSC_0.h</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="MSC" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Instance and Device Driver" maxInstances="4"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="MSC" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Instance and Device Driver" maxInstances="4"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1505,8 +1519,8 @@
       </file>
       <file attr="config" category="source" name="USB\Config\USB_Debug.c" version="1.0.0">
         <instance index="0">RTE\USB\USB_Debug.c</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
         </targetInfos>

--- a/Projects/Middleware/USB/Device/MassStorage/RTE/CMSIS-View/EventRecorderConf.h
+++ b/Projects/Middleware/USB/Device/MassStorage/RTE/CMSIS-View/EventRecorderConf.h
@@ -1,11 +1,24 @@
-/*------------------------------------------------------------------------------
- * MDK - Component ::Event Recorder
- * Copyright (c) 2016-2018 ARM Germany GmbH. All rights reserved.
- *------------------------------------------------------------------------------
+/*
+ * Copyright (c) 2016-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Name:    EventRecorderConf.h
- * Purpose: Event Recorder Configuration
+ * Purpose: Event Recorder software component configuration options
  * Rev.:    V1.1.0
- *----------------------------------------------------------------------------*/
+ */
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 

--- a/Projects/Middleware/USB/Device/MassStorage/RTE/CMSIS/RTX_Config.c
+++ b/Projects/Middleware/USB/Device/MassStorage/RTE/CMSIS/RTX_Config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.1
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration
@@ -54,6 +54,9 @@ __WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
       break;
     case osRtxErrorClibMutex:
       // Standard C/C++ library mutex initialization failed
+      break;
+    case osRtxErrorSVC:
+      // Invalid SVC function called (function=object_id)
       break;
     default:
       // Reserved

--- a/Projects/Middleware/USB/Device/MassStorage/RTE/CMSIS/RTX_Config.h
+++ b/Projects/Middleware/USB/Device/MassStorage/RTE/CMSIS/RTX_Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.5.2
+ * $Revision:   V5.6.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -69,6 +69,61 @@
 //     <i> Default: 5
 #ifndef OS_ROBIN_TIMEOUT
 #define OS_ROBIN_TIMEOUT            5
+#endif
+ 
+//   </e>
+ 
+//   <e>Safety features (Source variant only)
+//   <i> Enables FuSa related features.
+//   <i> Requires RTX Source variant.
+//   <i> Enables:
+//   <i>  - selected features from this group
+//   <i>  - Thread functions: osThreadProtectPrivileged
+#ifndef OS_SAFETY_FEATURES
+#define OS_SAFETY_FEATURES          0
+#endif
+ 
+//     <q>Safety Class
+//     <i> Threads assigned to lower classes cannot modify higher class threads.
+//     <i> Enables:
+//     <i>  - Object attributes: osSafetyClass
+//     <i>  - Kernel functions: osKernelProtect, osKernelDestroyClass
+//     <i>  - Thread functions: osThreadGetClass, osThreadSuspendClass, osThreadResumeClass
+#ifndef OS_SAFETY_CLASS
+#define OS_SAFETY_CLASS             1
+#endif
+ 
+//     <q>MPU Protected Zone
+//     <i> Access protection via MPU (Spatial isolation).
+//     <i> Enables:
+//     <i>  - Thread attributes: osThreadZone
+//     <i>  - Thread functions: osThreadGetZone, osThreadTerminateZone
+//     <i>  - Zone Management: osZoneSetup_Callback
+#ifndef OS_EXECUTION_ZONE
+#define OS_EXECUTION_ZONE           1
+#endif
+ 
+//     <q>Thread Watchdog
+//     <i> Watchdog alerts ensure timing for critical threads (Temporal isolation).
+//     <i> Enables:
+//     <i>  - Thread functions: osThreadFeedWatchdog
+//     <i>  - Handler functions: osWatchdogAlarm_Handler
+#ifndef OS_THREAD_WATCHDOG
+#define OS_THREAD_WATCHDOG          1
+#endif
+ 
+//     <q>Object Pointer checking
+//     <i> Check object pointer alignment and memory region.
+#ifndef OS_OBJ_PTR_CHECK
+#define OS_OBJ_PTR_CHECK            0
+#endif
+ 
+//     <q>SVC Function Pointer checking
+//     <i> Check SVC function pointer alignment and memory region.
+//     <i> User needs to define a linker execution region RTX_SVC_VENEERS
+//     <i> containing input sections: rtx_*.o (.text.os.svc.veneer.*)
+#ifndef OS_SVC_PTR_CHECK
+#define OS_SVC_PTR_CHECK            0
 #endif
  
 //   </e>
@@ -146,6 +201,20 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID    0
 #endif
  
+//   <o>Idle Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_CLASS
+#define OS_IDLE_THREAD_CLASS        0
+#endif
+ 
+//   <o>Idle Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_ZONE
+#define OS_IDLE_THREAD_ZONE         0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enables stack overrun check at thread switch (requires RTX source variant).
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -160,10 +229,10 @@
 #define OS_STACK_WATERMARK          0
 #endif
  
-//   <o>Processor mode for Thread execution
+//   <o>Default Processor mode for Thread execution
 //     <0=> Unprivileged mode
 //     <1=> Privileged mode
-//   <i> Default: Privileged mode
+//   <i> Default: Unprivileged mode
 #ifndef OS_PRIVILEGE_MODE
 #define OS_PRIVILEGE_MODE           1
 #endif
@@ -213,6 +282,20 @@
 //   <i> Default: 0 (not used)
 #ifndef OS_TIMER_THREAD_TZ_MOD_ID
 #define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_CLASS
+#define OS_TIMER_THREAD_CLASS       0
+#endif
+ 
+//   <o>Timer Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_ZONE
+#define OS_TIMER_THREAD_ZONE        0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>

--- a/Projects/Middleware/USB/Device/MassStorage/RTE/USB/USBD_Config_0.c
+++ b/Projects/Middleware/USB/Device/MassStorage/RTE/USB/USBD_Config_0.c
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBD_Config_0.c
  * Purpose: USB Device Configuration
- * Rev.:    V5.2.0
+ * Rev.:    V5.3.0
  *------------------------------------------------------------------------------
  * Use the following configuration settings in the Device Class configuration
  * files to assign a Device Class to this USB Device 0.
@@ -123,84 +123,5 @@
 //   </h>
 // </h>
 
-
-#include "RTE_Components.h"
-
-#ifdef  RTE_USB_Device_CustomClass_0
-#include "USBD_Config_CustomClass_0.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_1
-#include "USBD_Config_CustomClass_1.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_2
-#include "USBD_Config_CustomClass_2.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_3
-#include "USBD_Config_CustomClass_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_HID_0
-#include "USBD_Config_HID_0.h"
-#endif
-#ifdef  RTE_USB_Device_HID_1
-#include "USBD_Config_HID_1.h"
-#endif
-#ifdef  RTE_USB_Device_HID_2
-#include "USBD_Config_HID_2.h"
-#endif
-#ifdef  RTE_USB_Device_HID_3
-#include "USBD_Config_HID_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_MSC_0
-#include "USBD_Config_MSC_0.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_1
-#include "USBD_Config_MSC_1.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_2
-#include "USBD_Config_MSC_2.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_3
-#include "USBD_Config_MSC_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_CDC_0
-#include "USBD_Config_CDC_0.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_1
-#include "USBD_Config_CDC_1.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_2
-#include "USBD_Config_CDC_2.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_3
-#include "USBD_Config_CDC_3.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_4
-#include "USBD_Config_CDC_4.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_5
-#include "USBD_Config_CDC_5.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_6
-#include "USBD_Config_CDC_6.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_7
-#include "USBD_Config_CDC_7.h"
-#endif
-
-#ifdef  RTE_USB_Device_ADC_0
-#include "USBD_Config_ADC_0.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_1
-#include "USBD_Config_ADC_1.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_2
-#include "USBD_Config_ADC_2.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_3
-#include "USBD_Config_ADC_3.h"
-#endif
 
 #include "usbd_config.h"

--- a/Projects/Middleware/USB/Device/MassStorage/RTE/USB/USBD_Config_MSC_0.h
+++ b/Projects/Middleware/USB/Device/MassStorage/RTE/USB/USBD_Config_MSC_0.h
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBD_Config_MSC_0.h
  * Purpose: USB Device Mass Storage Class (MSC) Configuration
- * Rev.:    V5.1.1
+ * Rev.:    V5.2.0
  *----------------------------------------------------------------------------*/
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
@@ -64,7 +64,7 @@
 //   <i>in the USB component.
 //
 //     <s.126>MSC Interface String
-#define USBD_MSC0_STR_DESC              L"USB_MSC0"
+#define USBD_MSC0_STR_DESC_RAW          "USB_MSC0"
 
 //     <o0.0..1>Maximum Number of Logical Units (LUN)
 //     <i>For single LUN use 1, otherwise 2-4.

--- a/Projects/Middleware/USB/Device/VirtualCOM/Abstract.txt
+++ b/Projects/Middleware/USB/Device/VirtualCOM/Abstract.txt
@@ -38,14 +38,12 @@ The program is available in different targets:
 
  - Debug:
    - Compiler:                  ARM Compiler optimization Level 1
-   - Compiler:Event Recorder:   Enabled
-   - CMSIS:RTOS2:Keil RTX5:     Source
+   - CMSIS-View:Event Recorder: Enabled
    - USB:CORE:                  Debug
 
  - Release:
    - Compiler:                  ARM Compiler optimization Level 3
-   - Compiler:Event Recorder:   Disabled
-   - CMSIS:RTOS2:Keil RTX5:     Library
+   - CMSIS-View:Event Recorder: Disabled
    - USB:CORE:                  Release
 
 

--- a/Projects/Middleware/USB/Device/VirtualCOM/RTE/CMSIS-View/EventRecorderConf.h
+++ b/Projects/Middleware/USB/Device/VirtualCOM/RTE/CMSIS-View/EventRecorderConf.h
@@ -1,11 +1,24 @@
-/*------------------------------------------------------------------------------
- * MDK - Component ::Event Recorder
- * Copyright (c) 2016-2018 ARM Germany GmbH. All rights reserved.
- *------------------------------------------------------------------------------
+/*
+ * Copyright (c) 2016-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Name:    EventRecorderConf.h
- * Purpose: Event Recorder Configuration
+ * Purpose: Event Recorder software component configuration options
  * Rev.:    V1.1.0
- *----------------------------------------------------------------------------*/
+ */
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 

--- a/Projects/Middleware/USB/Device/VirtualCOM/RTE/CMSIS/RTX_Config.c
+++ b/Projects/Middleware/USB/Device/VirtualCOM/RTE/CMSIS/RTX_Config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.1
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration
@@ -54,6 +54,9 @@ __WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
       break;
     case osRtxErrorClibMutex:
       // Standard C/C++ library mutex initialization failed
+      break;
+    case osRtxErrorSVC:
+      // Invalid SVC function called (function=object_id)
       break;
     default:
       // Reserved

--- a/Projects/Middleware/USB/Device/VirtualCOM/RTE/CMSIS/RTX_Config.h
+++ b/Projects/Middleware/USB/Device/VirtualCOM/RTE/CMSIS/RTX_Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.5.2
+ * $Revision:   V5.6.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -69,6 +69,61 @@
 //     <i> Default: 5
 #ifndef OS_ROBIN_TIMEOUT
 #define OS_ROBIN_TIMEOUT            5
+#endif
+ 
+//   </e>
+ 
+//   <e>Safety features (Source variant only)
+//   <i> Enables FuSa related features.
+//   <i> Requires RTX Source variant.
+//   <i> Enables:
+//   <i>  - selected features from this group
+//   <i>  - Thread functions: osThreadProtectPrivileged
+#ifndef OS_SAFETY_FEATURES
+#define OS_SAFETY_FEATURES          0
+#endif
+ 
+//     <q>Safety Class
+//     <i> Threads assigned to lower classes cannot modify higher class threads.
+//     <i> Enables:
+//     <i>  - Object attributes: osSafetyClass
+//     <i>  - Kernel functions: osKernelProtect, osKernelDestroyClass
+//     <i>  - Thread functions: osThreadGetClass, osThreadSuspendClass, osThreadResumeClass
+#ifndef OS_SAFETY_CLASS
+#define OS_SAFETY_CLASS             1
+#endif
+ 
+//     <q>MPU Protected Zone
+//     <i> Access protection via MPU (Spatial isolation).
+//     <i> Enables:
+//     <i>  - Thread attributes: osThreadZone
+//     <i>  - Thread functions: osThreadGetZone, osThreadTerminateZone
+//     <i>  - Zone Management: osZoneSetup_Callback
+#ifndef OS_EXECUTION_ZONE
+#define OS_EXECUTION_ZONE           1
+#endif
+ 
+//     <q>Thread Watchdog
+//     <i> Watchdog alerts ensure timing for critical threads (Temporal isolation).
+//     <i> Enables:
+//     <i>  - Thread functions: osThreadFeedWatchdog
+//     <i>  - Handler functions: osWatchdogAlarm_Handler
+#ifndef OS_THREAD_WATCHDOG
+#define OS_THREAD_WATCHDOG          1
+#endif
+ 
+//     <q>Object Pointer checking
+//     <i> Check object pointer alignment and memory region.
+#ifndef OS_OBJ_PTR_CHECK
+#define OS_OBJ_PTR_CHECK            0
+#endif
+ 
+//     <q>SVC Function Pointer checking
+//     <i> Check SVC function pointer alignment and memory region.
+//     <i> User needs to define a linker execution region RTX_SVC_VENEERS
+//     <i> containing input sections: rtx_*.o (.text.os.svc.veneer.*)
+#ifndef OS_SVC_PTR_CHECK
+#define OS_SVC_PTR_CHECK            0
 #endif
  
 //   </e>
@@ -146,6 +201,20 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID    0
 #endif
  
+//   <o>Idle Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_CLASS
+#define OS_IDLE_THREAD_CLASS        0
+#endif
+ 
+//   <o>Idle Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_ZONE
+#define OS_IDLE_THREAD_ZONE         0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enables stack overrun check at thread switch (requires RTX source variant).
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -160,10 +229,10 @@
 #define OS_STACK_WATERMARK          0
 #endif
  
-//   <o>Processor mode for Thread execution
+//   <o>Default Processor mode for Thread execution
 //     <0=> Unprivileged mode
 //     <1=> Privileged mode
-//   <i> Default: Privileged mode
+//   <i> Default: Unprivileged mode
 #ifndef OS_PRIVILEGE_MODE
 #define OS_PRIVILEGE_MODE           1
 #endif
@@ -213,6 +282,20 @@
 //   <i> Default: 0 (not used)
 #ifndef OS_TIMER_THREAD_TZ_MOD_ID
 #define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_CLASS
+#define OS_TIMER_THREAD_CLASS       0
+#endif
+ 
+//   <o>Timer Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_ZONE
+#define OS_TIMER_THREAD_ZONE        0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>

--- a/Projects/Middleware/USB/Device/VirtualCOM/RTE/USB/USBD_Config_0.c
+++ b/Projects/Middleware/USB/Device/VirtualCOM/RTE/USB/USBD_Config_0.c
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBD_Config_0.c
  * Purpose: USB Device Configuration
- * Rev.:    V5.2.0
+ * Rev.:    V5.3.0
  *------------------------------------------------------------------------------
  * Use the following configuration settings in the Device Class configuration
  * files to assign a Device Class to this USB Device 0.
@@ -71,11 +71,11 @@
 
 //     <s.126>Manufacturer String
 //     <i>String Descriptor describing Manufacturer.
-#define USBD0_STR_DESC_MAN              L"Keil Software"
+#define USBD0_STR_DESC_MAN_RAW          "Keil Software"
 
 //     <s.126>Product String
 //     <i>String Descriptor describing Product.
-#define USBD0_STR_DESC_PROD             L"Keil USB Device 0"
+#define USBD0_STR_DESC_PROD_RAW         "Keil USB Device 0"
 
 //     <e.0>Serial Number String
 //     <i>Enable Serial Number String.
@@ -84,7 +84,7 @@
 
 //       <s.126>Default value
 //       <i>Default device's Serial Number String.
-#define USBD0_STR_DESC_SER              L"0001A0000000"
+#define USBD0_STR_DESC_SER_RAW          "0001A0000000"
 
 //       <o.0..7>Maximum Length (in characters) <0-126>
 //       <i>Specifies the maximum number of Serial Number String characters that can be set at run-time.
@@ -123,84 +123,5 @@
 //   </h>
 // </h>
 
-
-#include "RTE_Components.h"
-
-#ifdef  RTE_USB_Device_CustomClass_0
-#include "USBD_Config_CustomClass_0.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_1
-#include "USBD_Config_CustomClass_1.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_2
-#include "USBD_Config_CustomClass_2.h"
-#endif
-#ifdef  RTE_USB_Device_CustomClass_3
-#include "USBD_Config_CustomClass_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_HID_0
-#include "USBD_Config_HID_0.h"
-#endif
-#ifdef  RTE_USB_Device_HID_1
-#include "USBD_Config_HID_1.h"
-#endif
-#ifdef  RTE_USB_Device_HID_2
-#include "USBD_Config_HID_2.h"
-#endif
-#ifdef  RTE_USB_Device_HID_3
-#include "USBD_Config_HID_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_MSC_0
-#include "USBD_Config_MSC_0.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_1
-#include "USBD_Config_MSC_1.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_2
-#include "USBD_Config_MSC_2.h"
-#endif
-#ifdef  RTE_USB_Device_MSC_3
-#include "USBD_Config_MSC_3.h"
-#endif
-
-#ifdef  RTE_USB_Device_CDC_0
-#include "USBD_Config_CDC_0.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_1
-#include "USBD_Config_CDC_1.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_2
-#include "USBD_Config_CDC_2.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_3
-#include "USBD_Config_CDC_3.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_4
-#include "USBD_Config_CDC_4.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_5
-#include "USBD_Config_CDC_5.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_6
-#include "USBD_Config_CDC_6.h"
-#endif
-#ifdef  RTE_USB_Device_CDC_7
-#include "USBD_Config_CDC_7.h"
-#endif
-
-#ifdef  RTE_USB_Device_ADC_0
-#include "USBD_Config_ADC_0.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_1
-#include "USBD_Config_ADC_1.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_2
-#include "USBD_Config_ADC_2.h"
-#endif
-#ifdef  RTE_USB_Device_ADC_3
-#include "USBD_Config_ADC_3.h"
-#endif
 
 #include "usbd_config.h"

--- a/Projects/Middleware/USB/Device/VirtualCOM/RTE/USB/USBD_Config_CDC_0.h
+++ b/Projects/Middleware/USB/Device/VirtualCOM/RTE/USB/USBD_Config_CDC_0.h
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBD_Config_CDC_0.h
  * Purpose: USB Device Communication Device Class (CDC) Configuration
- * Rev.:    V5.2.0
+ * Rev.:    V5.3.0
  *----------------------------------------------------------------------------*/
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
@@ -129,10 +129,10 @@
 //   <i>in the USB component.
 //
 //     <s.126>Communication Class Interface String
-#define USBD_CDC0_CIF_STR_DESC           L"USB_CDC0_0"
+#define USBD_CDC0_CIF_STR_DESC_RAW       "USB_CDC0_0"
 
 //     <s.126>Data Class Interface String
-#define USBD_CDC0_DIF_STR_DESC           L"USB_CDC0_1"
+#define USBD_CDC0_DIF_STR_DESC_RAW       "USB_CDC0_1"
 
 //     <h>Abstract Control Model Settings
 
@@ -183,7 +183,7 @@
 
 //       <s.12>MAC Address String
 //       <i>Specifies 48-bit Ethernet MAC address.
-#define USBD_CDC0_NCM_MAC_ADDRESS        L"1E306CA2455E"
+#define USBD_CDC0_NCM_MAC_ADDRESS_RAW    "1E306CA2455E"
 
 //       <h>Ethernet Statistics
 //       <i>Specifies Ethernet statistic functions supported.

--- a/Projects/Middleware/USB/Device/VirtualCOM/VirtualCOM.uvoptx
+++ b/Projects/Middleware/USB/Device/VirtualCOM/VirtualCOM.uvoptx
@@ -155,23 +155,23 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\ARM_Compiler\1.7.2\EventRecorder.scvd</Filename>
-        <Type>Keil.ARM_Compiler.1.7.2</Type>
+        <Filename>C:\PACK\ARM\CMSIS-View\1.1.0\EventRecorder\EventRecorder.scvd</Filename>
+        <Type>ARM::CMSIS-View@1.1.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -355,13 +355,18 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
+        <SubType>1</SubType>
+      </ScvdPack>
+      <ScvdPack>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -549,7 +554,7 @@
   </Group>
 
   <Group>
-    <GroupName>::Compiler</GroupName>
+    <GroupName>::CMSIS-View</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/Projects/Middleware/USB/Device/VirtualCOM/VirtualCOM.uvprojx
+++ b/Projects/Middleware/USB/Device/VirtualCOM/VirtualCOM.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>Debug</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -329,7 +329,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -441,7 +441,7 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-View</GroupName>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -455,13 +455,13 @@
       <TargetName>Release</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -774,7 +774,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -886,7 +886,7 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-View</GroupName>
           <GroupOption>
             <CommonProperty>
               <UseCPPCompiler>0</UseCPPCompiler>
@@ -978,7 +978,7 @@
     </gpdscs>
     <boards>
       <board Bname="B-U585I-IOT02A" Brevision="Rev.C" Bvendor="STMicroelectronics" Bversion="Rev.C">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -987,49 +987,56 @@
     </boards>
     <apis>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="SPI" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.4.0" Cclass="CMSIS Driver" Cgroup="USART" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="Device" Cgroup="STM32Cube Framework" condition="STM32U5" exclusive="1">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.2" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1037,357 +1044,363 @@
       </api>
     </apis>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder" isTargetSpecific="1">
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.1"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="6.0.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Cvendor="ARM" Cversion="1.0.5" condition="OS Tick SysTick">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
+          <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5" isTargetSpecific="1">
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device" isTargetSpecific="1">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug">
-            <mem>
-              <RVCTZI>1</RVCTZI>
-            </mem>
-          </targetInfo>
+          <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="IIS2MDC" Cvendor="Keil" Cversion="1.1.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="ISM330DHCX" Cvendor="Keil" Cversion="1.1.3" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="TCPP0203" Cvendor="Keil" Cversion="1.2.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="BUS" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP BUS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Motion Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP MOTION SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="USB PD" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP USB PD">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Driver and Class Instance" maxInstances="4">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="CDC" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Instance and Device Driver" maxInstances="8">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="SPI" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver SPI">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS_Driver USART">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.0.0" condition="STM32U5 CMSIS_Driver USBD">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver USBD">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="1.2.0" condition="B-U585I-IOT02A VIO">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="2.0.0" condition="B-U585I-IOT02A VIO">
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube Framework" Csub="STM32CubeMX" Cvendor="Keil" Cversion="2.0.0" condition="STCubeMX" doc="C:/PACK/Keil/STM32U5xx_DFP/2.2.0/MDK/CubeMX/Documentation/cubemx.html" generated="1" generator="STM32CubeMX" selectable="1">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA DLYB">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA DLYB">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL GPIO Flash">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL GPIO Flash">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="CDC" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Instance and Device Driver" maxInstances="8">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Driver and Class Instance" maxInstances="4">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1398,7 +1411,7 @@
       <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\b_u585i_iot02a_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1407,25 +1420,34 @@
       <file attr="config" category="header" name="Drivers\Config\mx_wifi_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\mx_wifi_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="CMSIS\RTOS2\RTX\Config\RTX_Config.c" version="5.1.1">
+      <file attr="config" category="header" name="EventRecorder\Config\EventRecorderConf.h" version="1.1.0">
+        <instance index="0">RTE\CMSIS-View\EventRecorderConf.h</instance>
+        <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder"/>
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.1.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </file>
+      <file attr="config" category="source" name="Config\RTX_Config.c" version="5.2.0">
         <instance index="0">RTE\CMSIS\RTX_Config.c</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="CMSIS\RTOS2\RTX\Config\RTX_Config.h" version="5.5.2">
+      <file attr="config" category="header" name="Config\RTX_Config.h" version="5.6.0">
         <instance index="0">RTE\CMSIS\RTX_Config.h</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1434,24 +1456,16 @@
       <file attr="config" category="header" name="CMSIS\Driver\Config\WiFi_EMW3080_Config.h" version="1.0.0">
         <instance index="0">RTE\CMSIS_Driver\STM32U585AIIx\WiFi_EMW3080_Config.h</instance>
         <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="Config\EventRecorderConf.h" version="1.1.0">
-        <instance index="0">RTE\Compiler\EventRecorderConf.h</instance>
-        <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device"/>
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </file>
       <file attr="config" category="source" condition="STM32U585 ARMCC" name="MDK\Device\Source\arm\startup_stm32u585xx.s" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\startup_stm32u585xx.s</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1459,35 +1473,35 @@
       </file>
       <file attr="config" category="linkerScript" condition="STM32U585 noTZ ARMCC" name="MDK\Device\Source\arm\linker\stm32u585xx_flash.sct" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\stm32u585xx_flash.sct</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.2.0">
+      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.3.0">
         <instance index="0">RTE\Device\STM32U585AIIx\system_stm32u5xx.c</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="USB\Config\USBD_Config.c" version="5.2.0">
+      <file attr="config" category="source" name="USB\Config\USBD_Config.c" version="5.3.0">
         <instance index="0">RTE\USB\USBD_Config_0.c</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Driver and Class Instance" maxInstances="4"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Driver and Class Instance" maxInstances="4"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="USB\Config\USBD_Config_CDC.h" version="5.2.0">
+      <file attr="config" category="header" name="USB\Config\USBD_Config_CDC.h" version="5.3.0">
         <instance index="0">RTE\USB\USBD_Config_CDC_0.h</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="CDC" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Device Instance and Device Driver" maxInstances="8"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="Device" Csub="CDC" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Device Instance and Device Driver" maxInstances="8"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1495,8 +1509,8 @@
       </file>
       <file attr="config" category="source" name="USB\Config\USB_Debug.c" version="1.0.0">
         <instance index="0">RTE\USB\USB_Debug.c</instance>
-        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Plus" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
         </targetInfos>

--- a/Projects/Middleware/USB/Host/Keyboard/Abstract.txt
+++ b/Projects/Middleware/USB/Host/Keyboard/Abstract.txt
@@ -18,12 +18,10 @@ The program is available in different targets:
 
  - Debug:
    - Compiler:                  ARM Compiler optimization Level 1
-   - Compiler:Event Recorder:   Enabled
-   - CMSIS:RTOS2:Keil RTX5:     Source
+   - CMSIS-View:Event Recorder: Enabled
    - USB:CORE:                  Debug
 
  - Release:
    - Compiler:                  ARM Compiler optimization Level 3
-   - Compiler:Event Recorder:   Disabled
-   - CMSIS:RTOS2:Keil RTX5:     Library
+   - CMSIS-View:Event Recorder: Disabled
    - USB:CORE:                  Release

--- a/Projects/Middleware/USB/Host/Keyboard/Keyboard.uvoptx
+++ b/Projects/Middleware/USB/Host/Keyboard/Keyboard.uvoptx
@@ -155,23 +155,23 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\ARM_Compiler\1.7.2\EventRecorder.scvd</Filename>
-        <Type>Keil.ARM_Compiler.1.7.2</Type>
+        <Filename>C:\PACK\ARM\CMSIS-View\1.1.0\EventRecorder\EventRecorder.scvd</Filename>
+        <Type>ARM::CMSIS-View@1.1.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -355,13 +355,18 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
+        <SubType>1</SubType>
+      </ScvdPack>
+      <ScvdPack>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -537,7 +542,15 @@
   </Group>
 
   <Group>
-    <GroupName>::Compiler</GroupName>
+    <GroupName>::CMSIS-Compiler</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>1</RteFlg>
+  </Group>
+
+  <Group>
+    <GroupName>::CMSIS-View</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/Projects/Middleware/USB/Host/Keyboard/Keyboard.uvprojx
+++ b/Projects/Middleware/USB/Host/Keyboard/Keyboard.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>Debug</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -329,7 +329,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -436,7 +436,10 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-Compiler</GroupName>
+        </Group>
+        <Group>
+          <GroupName>::CMSIS-View</GroupName>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -450,13 +453,13 @@
       <TargetName>Release</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -876,7 +879,79 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-Compiler</GroupName>
+        </Group>
+        <Group>
+          <GroupName>::CMSIS-View</GroupName>
+          <GroupOption>
+            <CommonProperty>
+              <UseCPPCompiler>0</UseCPPCompiler>
+              <RVCTCodeConst>0</RVCTCodeConst>
+              <RVCTZI>0</RVCTZI>
+              <RVCTOtherData>0</RVCTOtherData>
+              <ModuleSelection>0</ModuleSelection>
+              <IncludeInBuild>0</IncludeInBuild>
+              <AlwaysBuild>2</AlwaysBuild>
+              <GenerateAssemblyFile>2</GenerateAssemblyFile>
+              <AssembleAssemblyFile>2</AssembleAssemblyFile>
+              <PublicsOnly>2</PublicsOnly>
+              <StopOnExitCode>11</StopOnExitCode>
+              <CustomArgument></CustomArgument>
+              <IncludeLibraryModules></IncludeLibraryModules>
+              <ComprImg>1</ComprImg>
+            </CommonProperty>
+            <GroupArmAds>
+              <Cads>
+                <interw>2</interw>
+                <Optim>0</Optim>
+                <oTime>2</oTime>
+                <SplitLS>2</SplitLS>
+                <OneElfS>2</OneElfS>
+                <Strict>2</Strict>
+                <EnumInt>2</EnumInt>
+                <PlainCh>2</PlainCh>
+                <Ropi>2</Ropi>
+                <Rwpi>2</Rwpi>
+                <wLevel>0</wLevel>
+                <uThumb>2</uThumb>
+                <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <uGnu>2</uGnu>
+                <useXO>2</useXO>
+                <v6Lang>0</v6Lang>
+                <v6LangP>0</v6LangP>
+                <vShortEn>2</vShortEn>
+                <vShortWch>2</vShortWch>
+                <v6Lto>2</v6Lto>
+                <v6WtE>2</v6WtE>
+                <v6Rtti>2</v6Rtti>
+                <VariousControls>
+                  <MiscControls></MiscControls>
+                  <Define></Define>
+                  <Undefine></Undefine>
+                  <IncludePath></IncludePath>
+                </VariousControls>
+              </Cads>
+              <Aads>
+                <interw>2</interw>
+                <Ropi>2</Ropi>
+                <Rwpi>2</Rwpi>
+                <thumb>2</thumb>
+                <SplitLS>2</SplitLS>
+                <SwStkChk>2</SwStkChk>
+                <NoWarn>2</NoWarn>
+                <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
+                <ClangAsOpt>0</ClangAsOpt>
+                <VariousControls>
+                  <MiscControls></MiscControls>
+                  <Define></Define>
+                  <Undefine></Undefine>
+                  <IncludePath></IncludePath>
+                </VariousControls>
+              </Aads>
+            </GroupArmAds>
+          </GroupOption>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -899,7 +974,7 @@
     </gpdscs>
     <boards>
       <board Bname="B-U585I-IOT02A" Brevision="Rev.C" Bvendor="STMicroelectronics" Bversion="Rev.C">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -908,49 +983,63 @@
     </boards>
     <apis>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="SPI" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.4.0" Cclass="CMSIS Driver" Cgroup="USART" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Host" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDOUT" condition="CortexDevice" exclusive="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="Device" Cgroup="STM32Cube Framework" condition="STM32U5" exclusive="1">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.2" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -958,364 +1047,382 @@
       </api>
     </apis>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-Compiler" Cgroup="CORE" Cvendor="ARM" Cversion="1.0.0" condition="ARMCC CortexDevice">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDOUT" Csub="ITM" Cvendor="ARM" Cversion="1.0.0" condition="CORE ITM">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
         <targetInfos>
+          <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.2" condition="Cortex-M Device" isTargetSpecific="1">
+        <package name="CMSIS-View" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="1.0.0"/>
+        <targetInfos>
+          <targetInfo excluded="1" name="Release" versionMatchMode="fixed"/>
+        </targetInfos>
+      </component>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder" isTargetSpecific="1">
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.1"/>
         <targetInfos>
           <targetInfo name="Debug"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device" isTargetSpecific="1">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="6.0.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
-          <targetInfo name="Debug">
-            <mem>
-              <RVCTZI>1</RVCTZI>
-            </mem>
-          </targetInfo>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="I/O" Csub="STDOUT" Cvariant="ITM" Cvendor="Keil" Cversion="1.2.0" condition="ARMCC Cortex-M with ITM">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Cvendor="ARM" Cversion="1.0.5" condition="OS Tick SysTick">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5" isTargetSpecific="1">
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="IIS2MDC" Cvendor="Keil" Cversion="1.1.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="ISM330DHCX" Cvendor="Keil" Cversion="1.1.3" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="TCPP0203" Cvendor="Keil" Cversion="1.2.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="BUS" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP BUS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Motion Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP MOTION SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="USB PD" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP USB PD">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Driver and Class Instance" maxInstances="4">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="HID" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Instance and Host Driver">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="SPI" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver SPI">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS_Driver USART">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Host" Csub="Full-speed" Cvendor="Keil" Cversion="1.0.0" condition="STM32U5 CMSIS_Driver USBH">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Host" Csub="Full-speed" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver USBH">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="1.2.0" condition="B-U585I-IOT02A VIO">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="2.0.0" condition="B-U585I-IOT02A VIO">
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube Framework" Csub="STM32CubeMX" Cvendor="Keil" Cversion="2.0.0" condition="STCubeMX" doc="C:/PACK/Keil/STM32U5xx_DFP/2.2.0/MDK/CubeMX/Documentation/cubemx.html" generated="1" generator="STM32CubeMX" selectable="1">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA DLYB">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA DLYB">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL GPIO Flash">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL GPIO Flash">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="HID" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Instance and Host Driver">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Driver and Class Instance" maxInstances="4">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1326,7 +1433,7 @@
       <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\b_u585i_iot02a_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1335,25 +1442,34 @@
       <file attr="config" category="header" name="Drivers\Config\mx_wifi_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\mx_wifi_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="CMSIS\RTOS2\RTX\Config\RTX_Config.c" version="5.1.1">
+      <file attr="config" category="header" name="EventRecorder\Config\EventRecorderConf.h" version="1.1.0">
+        <instance index="0">RTE\CMSIS-View\EventRecorderConf.h</instance>
+        <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder"/>
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.1.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </file>
+      <file attr="config" category="source" name="Config\RTX_Config.c" version="5.2.0">
         <instance index="0">RTE\CMSIS\RTX_Config.c</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="CMSIS\RTOS2\RTX\Config\RTX_Config.h" version="5.5.2">
+      <file attr="config" category="header" name="Config\RTX_Config.h" version="5.6.0">
         <instance index="0">RTE\CMSIS\RTX_Config.h</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1362,24 +1478,16 @@
       <file attr="config" category="header" name="CMSIS\Driver\Config\WiFi_EMW3080_Config.h" version="1.0.0">
         <instance index="0">RTE\CMSIS_Driver\STM32U585AIIx\WiFi_EMW3080_Config.h</instance>
         <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="Config\EventRecorderConf.h" version="1.1.0">
-        <instance index="0">RTE\Compiler\EventRecorderConf.h</instance>
-        <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device"/>
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </file>
       <file attr="config" category="source" condition="STM32U585 ARMCC" name="MDK\Device\Source\arm\startup_stm32u585xx.s" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\startup_stm32u585xx.s</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1387,26 +1495,26 @@
       </file>
       <file attr="config" category="linkerScript" condition="STM32U585 noTZ ARMCC" name="MDK\Device\Source\arm\linker\stm32u585xx_flash.sct" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\stm32u585xx_flash.sct</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.2.0">
+      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.3.0">
         <instance index="0">RTE\Device\STM32U585AIIx\system_stm32u5xx.c</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="USB\Config\USBH_Config.c" version="5.2.1">
+      <file attr="config" category="source" name="USB\Config\USBH_Config.c" version="5.3.0">
         <instance index="0">RTE\USB\USBH_Config_0.c</instance>
-        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Driver and Class Instance" maxInstances="4"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Driver and Class Instance" maxInstances="4"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1414,8 +1522,8 @@
       </file>
       <file attr="config" category="header" name="USB\Config\USBH_Config_HID.h" version="5.1.0">
         <instance index="0">RTE\USB\USBH_Config_HID.h</instance>
-        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="HID" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Instance and Host Driver"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="HID" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Instance and Host Driver"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1423,8 +1531,8 @@
       </file>
       <file attr="config" category="source" name="USB\Config\USB_Debug.c" version="1.0.0">
         <instance index="0">RTE\USB\USB_Debug.c</instance>
-        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
         </targetInfos>

--- a/Projects/Middleware/USB/Host/Keyboard/RTE/CMSIS-View/EventRecorderConf.h
+++ b/Projects/Middleware/USB/Host/Keyboard/RTE/CMSIS-View/EventRecorderConf.h
@@ -1,11 +1,24 @@
-/*------------------------------------------------------------------------------
- * MDK - Component ::Event Recorder
- * Copyright (c) 2016-2018 ARM Germany GmbH. All rights reserved.
- *------------------------------------------------------------------------------
+/*
+ * Copyright (c) 2016-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Name:    EventRecorderConf.h
- * Purpose: Event Recorder Configuration
+ * Purpose: Event Recorder software component configuration options
  * Rev.:    V1.1.0
- *----------------------------------------------------------------------------*/
+ */
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 

--- a/Projects/Middleware/USB/Host/Keyboard/RTE/CMSIS/RTX_Config.c
+++ b/Projects/Middleware/USB/Host/Keyboard/RTE/CMSIS/RTX_Config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.1
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration
@@ -54,6 +54,9 @@ __WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
       break;
     case osRtxErrorClibMutex:
       // Standard C/C++ library mutex initialization failed
+      break;
+    case osRtxErrorSVC:
+      // Invalid SVC function called (function=object_id)
       break;
     default:
       // Reserved

--- a/Projects/Middleware/USB/Host/Keyboard/RTE/CMSIS/RTX_Config.h
+++ b/Projects/Middleware/USB/Host/Keyboard/RTE/CMSIS/RTX_Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.5.2
+ * $Revision:   V5.6.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -69,6 +69,61 @@
 //     <i> Default: 5
 #ifndef OS_ROBIN_TIMEOUT
 #define OS_ROBIN_TIMEOUT            5
+#endif
+ 
+//   </e>
+ 
+//   <e>Safety features (Source variant only)
+//   <i> Enables FuSa related features.
+//   <i> Requires RTX Source variant.
+//   <i> Enables:
+//   <i>  - selected features from this group
+//   <i>  - Thread functions: osThreadProtectPrivileged
+#ifndef OS_SAFETY_FEATURES
+#define OS_SAFETY_FEATURES          0
+#endif
+ 
+//     <q>Safety Class
+//     <i> Threads assigned to lower classes cannot modify higher class threads.
+//     <i> Enables:
+//     <i>  - Object attributes: osSafetyClass
+//     <i>  - Kernel functions: osKernelProtect, osKernelDestroyClass
+//     <i>  - Thread functions: osThreadGetClass, osThreadSuspendClass, osThreadResumeClass
+#ifndef OS_SAFETY_CLASS
+#define OS_SAFETY_CLASS             1
+#endif
+ 
+//     <q>MPU Protected Zone
+//     <i> Access protection via MPU (Spatial isolation).
+//     <i> Enables:
+//     <i>  - Thread attributes: osThreadZone
+//     <i>  - Thread functions: osThreadGetZone, osThreadTerminateZone
+//     <i>  - Zone Management: osZoneSetup_Callback
+#ifndef OS_EXECUTION_ZONE
+#define OS_EXECUTION_ZONE           1
+#endif
+ 
+//     <q>Thread Watchdog
+//     <i> Watchdog alerts ensure timing for critical threads (Temporal isolation).
+//     <i> Enables:
+//     <i>  - Thread functions: osThreadFeedWatchdog
+//     <i>  - Handler functions: osWatchdogAlarm_Handler
+#ifndef OS_THREAD_WATCHDOG
+#define OS_THREAD_WATCHDOG          1
+#endif
+ 
+//     <q>Object Pointer checking
+//     <i> Check object pointer alignment and memory region.
+#ifndef OS_OBJ_PTR_CHECK
+#define OS_OBJ_PTR_CHECK            0
+#endif
+ 
+//     <q>SVC Function Pointer checking
+//     <i> Check SVC function pointer alignment and memory region.
+//     <i> User needs to define a linker execution region RTX_SVC_VENEERS
+//     <i> containing input sections: rtx_*.o (.text.os.svc.veneer.*)
+#ifndef OS_SVC_PTR_CHECK
+#define OS_SVC_PTR_CHECK            0
 #endif
  
 //   </e>
@@ -146,6 +201,20 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID    0
 #endif
  
+//   <o>Idle Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_CLASS
+#define OS_IDLE_THREAD_CLASS        0
+#endif
+ 
+//   <o>Idle Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_ZONE
+#define OS_IDLE_THREAD_ZONE         0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enables stack overrun check at thread switch (requires RTX source variant).
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -160,10 +229,10 @@
 #define OS_STACK_WATERMARK          0
 #endif
  
-//   <o>Processor mode for Thread execution
+//   <o>Default Processor mode for Thread execution
 //     <0=> Unprivileged mode
 //     <1=> Privileged mode
-//   <i> Default: Privileged mode
+//   <i> Default: Unprivileged mode
 #ifndef OS_PRIVILEGE_MODE
 #define OS_PRIVILEGE_MODE           1
 #endif
@@ -213,6 +282,20 @@
 //   <i> Default: 0 (not used)
 #ifndef OS_TIMER_THREAD_TZ_MOD_ID
 #define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_CLASS
+#define OS_TIMER_THREAD_CLASS       0
+#endif
+ 
+//   <o>Timer Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_ZONE
+#define OS_TIMER_THREAD_ZONE        0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>

--- a/Projects/Middleware/USB/Host/Keyboard/RTE/USB/USBH_Config_0.c
+++ b/Projects/Middleware/USB/Host/Keyboard/RTE/USB/USBH_Config_0.c
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Host
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBH_Config_0.c
  * Purpose: USB Host Configuration
- * Rev.:    V5.2.1
+ * Rev.:    V5.3.0
  *----------------------------------------------------------------------------*/
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
@@ -120,23 +120,5 @@
 //   </h>
 // </h>
 
-
-#include "RTE_Components.h"
-
-#ifdef  RTE_USB_Host_MSC
-#include "USBH_Config_MSC.h"
-#endif
-
-#ifdef  RTE_USB_Host_HID
-#include "USBH_Config_HID.h"
-#endif
-
-#ifdef  RTE_USB_Host_CDC
-#include "USBH_Config_CDC.h"
-#endif
-
-#ifdef  RTE_USB_Host_CustomClass
-#include "USBH_Config_CustomClass.h"
-#endif
 
 #include "usbh_config.h"

--- a/Projects/Middleware/USB/Host/MassStorage/Abstract.txt
+++ b/Projects/Middleware/USB/Host/MassStorage/Abstract.txt
@@ -19,14 +19,12 @@ The program is available in different targets:
 
  - Debug:
    - Compiler:                  ARM Compiler optimization Level 1
-   - Compiler:Event Recorder:   Enabled
-   - CMSIS:RTOS2:Keil RTX5:     Source
+   - CMSIS-View:Event Recorder: Enabled
    - USB:CORE:                  Debug
    - File System:CORE:          LFN Debug
 
  - Release:
    - Compiler:                  ARM Compiler optimization Level 3
-   - Compiler:Event Recorder:   Disabled
-   - CMSIS:RTOS2:Keil RTX5:     Library
+   - CMSIS-View:Event Recorder: Disabled
    - USB:CORE:                  Release
    - File System:CORE:          LFN

--- a/Projects/Middleware/USB/Host/MassStorage/MassStorage.uvoptx
+++ b/Projects/Middleware/USB/Host/MassStorage/MassStorage.uvoptx
@@ -155,28 +155,28 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\ARM_Compiler\1.7.2\EventRecorder.scvd</Filename>
-        <Type>Keil.ARM_Compiler.1.7.2</Type>
+        <Filename>C:\PACK\ARM\CMSIS-View\1.1.0\EventRecorder\EventRecorder.scvd</Filename>
+        <Type>ARM::CMSIS-View@1.1.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\FileSystem\FileSystem.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\FileSystem\FileSystem.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -360,18 +360,23 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\FileSystem\FileSystem.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\FileSystem\FileSystem.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\MDK-Middleware\7.16.0\USB\USB.scvd</Filename>
-        <Type>Keil.MDK-Middleware.7.16.0</Type>
+        <Filename>C:\PACK\Keil\MDK-Middleware\7.17.0\USB\USB.scvd</Filename>
+        <Type>Keil::MDK-Middleware@7.17.0</Type>
+        <SubType>1</SubType>
+      </ScvdPack>
+      <ScvdPack>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -559,7 +564,15 @@
   </Group>
 
   <Group>
-    <GroupName>::Compiler</GroupName>
+    <GroupName>::CMSIS-Compiler</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>1</RteFlg>
+  </Group>
+
+  <Group>
+    <GroupName>::CMSIS-View</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/Projects/Middleware/USB/Host/MassStorage/MassStorage.uvprojx
+++ b/Projects/Middleware/USB/Host/MassStorage/MassStorage.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>Debug</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -329,7 +329,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -441,7 +441,10 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-Compiler</GroupName>
+        </Group>
+        <Group>
+          <GroupName>::CMSIS-View</GroupName>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -458,13 +461,13 @@
       <TargetName>Release</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -777,7 +780,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>3</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -889,7 +892,79 @@
           <GroupName>::CMSIS Driver</GroupName>
         </Group>
         <Group>
-          <GroupName>::Compiler</GroupName>
+          <GroupName>::CMSIS-Compiler</GroupName>
+        </Group>
+        <Group>
+          <GroupName>::CMSIS-View</GroupName>
+          <GroupOption>
+            <CommonProperty>
+              <UseCPPCompiler>0</UseCPPCompiler>
+              <RVCTCodeConst>0</RVCTCodeConst>
+              <RVCTZI>0</RVCTZI>
+              <RVCTOtherData>0</RVCTOtherData>
+              <ModuleSelection>0</ModuleSelection>
+              <IncludeInBuild>0</IncludeInBuild>
+              <AlwaysBuild>2</AlwaysBuild>
+              <GenerateAssemblyFile>2</GenerateAssemblyFile>
+              <AssembleAssemblyFile>2</AssembleAssemblyFile>
+              <PublicsOnly>2</PublicsOnly>
+              <StopOnExitCode>11</StopOnExitCode>
+              <CustomArgument></CustomArgument>
+              <IncludeLibraryModules></IncludeLibraryModules>
+              <ComprImg>1</ComprImg>
+            </CommonProperty>
+            <GroupArmAds>
+              <Cads>
+                <interw>2</interw>
+                <Optim>0</Optim>
+                <oTime>2</oTime>
+                <SplitLS>2</SplitLS>
+                <OneElfS>2</OneElfS>
+                <Strict>2</Strict>
+                <EnumInt>2</EnumInt>
+                <PlainCh>2</PlainCh>
+                <Ropi>2</Ropi>
+                <Rwpi>2</Rwpi>
+                <wLevel>0</wLevel>
+                <uThumb>2</uThumb>
+                <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <uGnu>2</uGnu>
+                <useXO>2</useXO>
+                <v6Lang>0</v6Lang>
+                <v6LangP>0</v6LangP>
+                <vShortEn>2</vShortEn>
+                <vShortWch>2</vShortWch>
+                <v6Lto>2</v6Lto>
+                <v6WtE>2</v6WtE>
+                <v6Rtti>2</v6Rtti>
+                <VariousControls>
+                  <MiscControls></MiscControls>
+                  <Define></Define>
+                  <Undefine></Undefine>
+                  <IncludePath></IncludePath>
+                </VariousControls>
+              </Cads>
+              <Aads>
+                <interw>2</interw>
+                <Ropi>2</Ropi>
+                <Rwpi>2</Rwpi>
+                <thumb>2</thumb>
+                <SplitLS>2</SplitLS>
+                <SwStkChk>2</SwStkChk>
+                <NoWarn>2</NoWarn>
+                <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
+                <ClangAsOpt>0</ClangAsOpt>
+                <VariousControls>
+                  <MiscControls></MiscControls>
+                  <Define></Define>
+                  <Undefine></Undefine>
+                  <IncludePath></IncludePath>
+                </VariousControls>
+              </Aads>
+            </GroupArmAds>
+          </GroupOption>
         </Group>
         <Group>
           <GroupName>::Device</GroupName>
@@ -915,7 +990,7 @@
     </gpdscs>
     <boards>
       <board Bname="B-U585I-IOT02A" Brevision="Rev.C" Bvendor="STMicroelectronics" Bversion="Rev.C">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -924,49 +999,63 @@
     </boards>
     <apis>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="SPI" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.4.0" Cclass="CMSIS Driver" Cgroup="USART" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Host" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
-      <api Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="File Interface" condition="CortexDevice" exclusive="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1" isTargetSpecific="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="Device" Cgroup="STM32Cube Framework" condition="STM32U5" exclusive="1">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.2" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -974,383 +1063,396 @@
       </api>
     </apis>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-Compiler" Cgroup="CORE" Cvendor="ARM" Cversion="1.0.0" condition="ARMCC CortexDevice">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder" isTargetSpecific="1">
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.1"/>
         <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="6.0.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5" isTargetSpecific="1">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Cvendor="ARM" Cversion="1.0.5" condition="OS Tick SysTick">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device" isTargetSpecific="1">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug">
-            <mem>
-              <RVCTZI>1</RVCTZI>
-            </mem>
-          </targetInfo>
-        </targetInfos>
-      </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="I/O" Csub="File" Cvariant="File System" Cvendor="Keil" Cversion="1.2.0" condition="ARMCC Cortex-M with File System">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5" isTargetSpecific="1">
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="IIS2MDC" Cvendor="Keil" Cversion="1.1.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="ISM330DHCX" Cvendor="Keil" Cversion="1.1.3" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="TCPP0203" Cvendor="Keil" Cversion="1.2.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="BUS" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP BUS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Motion Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP MOTION SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="USB PD" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP USB PD">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and File System I/O and Event Recorder" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and File System I/O" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="Drive" Csub="USB" Cvendor="Keil" Cversion="6.16.2" condition="File System and USB Host MSC" maxInstances="2">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS" isTargetSpecific="1">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Driver and Class Instance" maxInstances="4">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-          <targetInfo name="Release"/>
-        </targetInfos>
-      </component>
-      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="MSC" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Instance and Host Driver and File System USB Drive">
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="SPI" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver SPI">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS_Driver USART">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Host" Csub="Full-speed" Cvendor="Keil" Cversion="1.0.0" condition="STM32U5 CMSIS_Driver USBH">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Host" Csub="Full-speed" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver USBH">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="1.2.0" condition="B-U585I-IOT02A VIO">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="2.0.0" condition="B-U585I-IOT02A VIO">
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
       <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="File Interface" Csub="MDK-MW File System" Cvendor="Keil" Cversion="1.0.0" condition="File System and CMSIS Compiler">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube Framework" Csub="STM32CubeMX" Cvendor="Keil" Cversion="2.0.0" condition="STCubeMX" doc="C:/PACK/Keil/STM32U5xx_DFP/2.2.0/MDK/CubeMX/Documentation/cubemx.html" generated="1" generator="STM32CubeMX" selectable="1">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA DLYB">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA DLYB">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL GPIO Flash">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL GPIO Flash">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN Debug" Cvendor="Keil" Cversion="6.16.6" condition="CMSIS Core with RTOS and File System I/O and Event Recorder" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN" Cvendor="Keil" Cversion="6.16.6" condition="CMSIS Core with RTOS and File System I/O" isDefaultVariant="1" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="Drive" Csub="USB" Cvendor="Keil" Cversion="6.16.6" condition="File System and USB Host MSC" maxInstances="2">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Release" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS" isTargetSpecific="1">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="MSC" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Instance and Host Driver and File System USB Drive">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo name="Release"/>
+        </targetInfos>
+      </component>
+      <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Driver and Class Instance" maxInstances="4">
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1361,7 +1463,7 @@
       <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\b_u585i_iot02a_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1370,25 +1472,34 @@
       <file attr="config" category="header" name="Drivers\Config\mx_wifi_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\mx_wifi_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="CMSIS\RTOS2\RTX\Config\RTX_Config.c" version="5.1.1">
+      <file attr="config" category="header" name="EventRecorder\Config\EventRecorderConf.h" version="1.1.0">
+        <instance index="0">RTE\CMSIS-View\EventRecorderConf.h</instance>
+        <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder"/>
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.1.0"/>
+        <targetInfos>
+          <targetInfo name="Debug"/>
+          <targetInfo excluded="1" name="Release"/>
+        </targetInfos>
+      </file>
+      <file attr="config" category="source" name="Config\RTX_Config.c" version="5.2.0">
         <instance index="0">RTE\CMSIS\RTX_Config.c</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="CMSIS\RTOS2\RTX\Config\RTX_Config.h" version="5.5.2">
+      <file attr="config" category="header" name="Config\RTX_Config.h" version="5.6.0">
         <instance index="0">RTE\CMSIS\RTX_Config.h</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Library" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1397,24 +1508,16 @@
       <file attr="config" category="header" name="CMSIS\Driver\Config\WiFi_EMW3080_Config.h" version="1.0.0">
         <instance index="0">RTE\CMSIS_Driver\STM32U585AIIx\WiFi_EMW3080_Config.h</instance>
         <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="Config\EventRecorderConf.h" version="1.1.0">
-        <instance index="0">RTE\Compiler\EventRecorderConf.h</instance>
-        <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device"/>
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
-        <targetInfos>
-          <targetInfo name="Debug"/>
-        </targetInfos>
-      </file>
       <file attr="config" category="source" condition="STM32U585 ARMCC" name="MDK\Device\Source\arm\startup_stm32u585xx.s" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\startup_stm32u585xx.s</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1422,26 +1525,26 @@
       </file>
       <file attr="config" category="linkerScript" condition="STM32U585 noTZ ARMCC" name="MDK\Device\Source\arm\linker\stm32u585xx_flash.sct" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\stm32u585xx_flash.sct</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.2.0">
+      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.3.0">
         <instance index="0">RTE\Device\STM32U585AIIx\system_stm32u5xx.c</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="FileSystem\Config\FS_Config.c" version="6.3.0">
+      <file attr="config" category="source" name="FileSystem\Config\FS_Config.c" version="6.4.0">
         <instance index="0">RTE\File_System\FS_Config.c</instance>
-        <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and File System I/O" isDefaultVariant="1"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN" Cvendor="Keil" Cversion="6.16.6" condition="CMSIS Core with RTOS and File System I/O" isDefaultVariant="1"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1449,8 +1552,8 @@
       </file>
       <file attr="config" category="header" name="FileSystem\Config\FS_Config_USB.h" version="6.2.0">
         <instance index="0">RTE\File_System\FS_Config_USB_0.h</instance>
-        <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="Drive" Csub="USB" Cvendor="Keil" Cversion="6.16.2" condition="File System and USB Host MSC" maxInstances="2"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="Drive" Csub="USB" Cvendor="Keil" Cversion="6.16.6" condition="File System and USB Host MSC" maxInstances="2"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1458,16 +1561,16 @@
       </file>
       <file attr="config" category="source" name="FileSystem\Config\FS_Debug.c" version="1.0.0">
         <instance index="0">RTE\File_System\FS_Debug.c</instance>
-        <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and File System I/O and Event Recorder"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="File System" Cgroup="CORE" Cvariant="LFN Debug" Cvendor="Keil" Cversion="6.16.6" condition="CMSIS Core with RTOS and File System I/O and Event Recorder"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="USB\Config\USBH_Config.c" version="5.2.1">
+      <file attr="config" category="source" name="USB\Config\USBH_Config.c" version="5.3.0">
         <instance index="0">RTE\USB\USBH_Config_0.c</instance>
-        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Driver and Class Instance" maxInstances="4"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Driver and Class Instance" maxInstances="4"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1475,8 +1578,8 @@
       </file>
       <file attr="config" category="header" name="USB\Config\USBH_Config_MSC.h" version="5.0.0">
         <instance index="0">RTE\USB\USBH_Config_MSC.h</instance>
-        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="MSC" Cvendor="Keil" Cversion="6.16.2" condition="USB Core and Host Instance and Host Driver and File System USB Drive"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="Host" Csub="MSC" Cvendor="Keil" Cversion="6.17.0" condition="USB Core and Host Instance and Host Driver and File System USB Drive"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
           <targetInfo name="Release"/>
@@ -1484,8 +1587,8 @@
       </file>
       <file attr="config" category="source" name="USB\Config\USB_Debug.c" version="1.0.0">
         <instance index="0">RTE\USB\USB_Debug.c</instance>
-        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.16.2" condition="CMSIS Core with RTOS and Event Recorder"/>
-        <package name="MDK-Middleware" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="7.16.0"/>
+        <component Cbundle="MDK-Pro" Cclass="USB" Cgroup="CORE" Cvariant="Debug" Cvendor="Keil" Cversion="6.17.0" condition="CMSIS Core with RTOS and Event Recorder"/>
+        <package name="MDK-Middleware" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="7.17.0"/>
         <targetInfos>
           <targetInfo name="Debug"/>
         </targetInfos>

--- a/Projects/Middleware/USB/Host/MassStorage/RTE/CMSIS-View/EventRecorderConf.h
+++ b/Projects/Middleware/USB/Host/MassStorage/RTE/CMSIS-View/EventRecorderConf.h
@@ -1,11 +1,24 @@
-/*------------------------------------------------------------------------------
- * MDK - Component ::Event Recorder
- * Copyright (c) 2016-2018 ARM Germany GmbH. All rights reserved.
- *------------------------------------------------------------------------------
+/*
+ * Copyright (c) 2016-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Name:    EventRecorderConf.h
- * Purpose: Event Recorder Configuration
+ * Purpose: Event Recorder software component configuration options
  * Rev.:    V1.1.0
- *----------------------------------------------------------------------------*/
+ */
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 

--- a/Projects/Middleware/USB/Host/MassStorage/RTE/CMSIS/RTX_Config.c
+++ b/Projects/Middleware/USB/Host/MassStorage/RTE/CMSIS/RTX_Config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.1
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration
@@ -54,6 +54,9 @@ __WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
       break;
     case osRtxErrorClibMutex:
       // Standard C/C++ library mutex initialization failed
+      break;
+    case osRtxErrorSVC:
+      // Invalid SVC function called (function=object_id)
       break;
     default:
       // Reserved

--- a/Projects/Middleware/USB/Host/MassStorage/RTE/CMSIS/RTX_Config.h
+++ b/Projects/Middleware/USB/Host/MassStorage/RTE/CMSIS/RTX_Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.5.2
+ * $Revision:   V5.6.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -69,6 +69,61 @@
 //     <i> Default: 5
 #ifndef OS_ROBIN_TIMEOUT
 #define OS_ROBIN_TIMEOUT            5
+#endif
+ 
+//   </e>
+ 
+//   <e>Safety features (Source variant only)
+//   <i> Enables FuSa related features.
+//   <i> Requires RTX Source variant.
+//   <i> Enables:
+//   <i>  - selected features from this group
+//   <i>  - Thread functions: osThreadProtectPrivileged
+#ifndef OS_SAFETY_FEATURES
+#define OS_SAFETY_FEATURES          0
+#endif
+ 
+//     <q>Safety Class
+//     <i> Threads assigned to lower classes cannot modify higher class threads.
+//     <i> Enables:
+//     <i>  - Object attributes: osSafetyClass
+//     <i>  - Kernel functions: osKernelProtect, osKernelDestroyClass
+//     <i>  - Thread functions: osThreadGetClass, osThreadSuspendClass, osThreadResumeClass
+#ifndef OS_SAFETY_CLASS
+#define OS_SAFETY_CLASS             1
+#endif
+ 
+//     <q>MPU Protected Zone
+//     <i> Access protection via MPU (Spatial isolation).
+//     <i> Enables:
+//     <i>  - Thread attributes: osThreadZone
+//     <i>  - Thread functions: osThreadGetZone, osThreadTerminateZone
+//     <i>  - Zone Management: osZoneSetup_Callback
+#ifndef OS_EXECUTION_ZONE
+#define OS_EXECUTION_ZONE           1
+#endif
+ 
+//     <q>Thread Watchdog
+//     <i> Watchdog alerts ensure timing for critical threads (Temporal isolation).
+//     <i> Enables:
+//     <i>  - Thread functions: osThreadFeedWatchdog
+//     <i>  - Handler functions: osWatchdogAlarm_Handler
+#ifndef OS_THREAD_WATCHDOG
+#define OS_THREAD_WATCHDOG          1
+#endif
+ 
+//     <q>Object Pointer checking
+//     <i> Check object pointer alignment and memory region.
+#ifndef OS_OBJ_PTR_CHECK
+#define OS_OBJ_PTR_CHECK            0
+#endif
+ 
+//     <q>SVC Function Pointer checking
+//     <i> Check SVC function pointer alignment and memory region.
+//     <i> User needs to define a linker execution region RTX_SVC_VENEERS
+//     <i> containing input sections: rtx_*.o (.text.os.svc.veneer.*)
+#ifndef OS_SVC_PTR_CHECK
+#define OS_SVC_PTR_CHECK            0
 #endif
  
 //   </e>
@@ -146,6 +201,20 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID    0
 #endif
  
+//   <o>Idle Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_CLASS
+#define OS_IDLE_THREAD_CLASS        0
+#endif
+ 
+//   <o>Idle Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_ZONE
+#define OS_IDLE_THREAD_ZONE         0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enables stack overrun check at thread switch (requires RTX source variant).
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -160,10 +229,10 @@
 #define OS_STACK_WATERMARK          0
 #endif
  
-//   <o>Processor mode for Thread execution
+//   <o>Default Processor mode for Thread execution
 //     <0=> Unprivileged mode
 //     <1=> Privileged mode
-//   <i> Default: Privileged mode
+//   <i> Default: Unprivileged mode
 #ifndef OS_PRIVILEGE_MODE
 #define OS_PRIVILEGE_MODE           1
 #endif
@@ -213,6 +282,20 @@
 //   <i> Default: 0 (not used)
 #ifndef OS_TIMER_THREAD_TZ_MOD_ID
 #define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_CLASS
+#define OS_TIMER_THREAD_CLASS       0
+#endif
+ 
+//   <o>Timer Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_ZONE
+#define OS_TIMER_THREAD_ZONE        0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>

--- a/Projects/Middleware/USB/Host/MassStorage/RTE/File_System/FS_Config.c
+++ b/Projects/Middleware/USB/Host/MassStorage/RTE/File_System/FS_Config.c
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config.c
  * Purpose: File System Configuration
- * Rev.:    V6.3.0
+ * Rev.:    V6.4.0
  *----------------------------------------------------------------------------*/
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
@@ -37,42 +37,5 @@
 // <i>Set initial setting for current drive. Current drive is used for File System functions
 // <i>that are invoked with the "" string and can be altered anytime during run-time.
 #define FS_INITIAL_CDRIVE       7
-
-#include "RTE_Components.h"
-
-#ifdef  RTE_FileSystem_Drive_RAM_0
-#include "FS_Config_RAM_0.h"
-#endif
-#ifdef  RTE_FileSystem_Drive_RAM_1
-#include "FS_Config_RAM_1.h"
-#endif
-
-#ifdef  RTE_FileSystem_Drive_NOR_0
-#include "FS_Config_NOR_0.h"
-#endif
-#ifdef  RTE_FileSystem_Drive_NOR_1
-#include "FS_Config_NOR_1.h"
-#endif
-
-#ifdef  RTE_FileSystem_Drive_NAND_0
-#include "FS_Config_NAND_0.h"
-#endif
-#ifdef  RTE_FileSystem_Drive_NAND_1
-#include "FS_Config_NAND_1.h"
-#endif
-
-#ifdef  RTE_FileSystem_Drive_MC_0
-#include "FS_Config_MC_0.h"
-#endif
-#ifdef  RTE_FileSystem_Drive_MC_1
-#include "FS_Config_MC_1.h"
-#endif
-
-#ifdef  RTE_FileSystem_Drive_USB_0
-#include "FS_Config_USB_0.h"
-#endif
-#ifdef  RTE_FileSystem_Drive_USB_1
-#include "FS_Config_USB_1.h"
-#endif
 
 #include "fs_config.h"

--- a/Projects/Middleware/USB/Host/MassStorage/RTE/USB/USBH_Config_0.c
+++ b/Projects/Middleware/USB/Host/MassStorage/RTE/USB/USBH_Config_0.c
@@ -1,10 +1,10 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Host
- * Copyright (c) 2004-2019 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    USBH_Config_0.c
  * Purpose: USB Host Configuration
- * Rev.:    V5.2.1
+ * Rev.:    V5.3.0
  *----------------------------------------------------------------------------*/
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
@@ -120,23 +120,5 @@
 //   </h>
 // </h>
 
-
-#include "RTE_Components.h"
-
-#ifdef  RTE_USB_Host_MSC
-#include "USBH_Config_MSC.h"
-#endif
-
-#ifdef  RTE_USB_Host_HID
-#include "USBH_Config_HID.h"
-#endif
-
-#ifdef  RTE_USB_Host_CDC
-#include "USBH_Config_CDC.h"
-#endif
-
-#ifdef  RTE_USB_Host_CustomClass
-#include "USBH_Config_CustomClass.h"
-#endif
 
 #include "usbh_config.h"

--- a/Projects/Platform/Platform.uvoptx
+++ b/Projects/Platform/Platform.uvoptx
@@ -155,18 +155,18 @@
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-View\1.1.0\EventRecorder\EventRecorder.scvd</Filename>
+        <Type>ARM::CMSIS-View@1.1.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd</Filename>
-        <Type>ARM.CMSIS.5.9.0</Type>
+        <Filename>C:\PACK\ARM\CMSIS-RTX\5.8.0\RTX5.scvd</Filename>
+        <Type>ARM::CMSIS-RTX@5.8.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <ScvdPack>
-        <Filename>C:\ARM\PACK\Keil\ARM_Compiler\1.7.2\EventRecorder.scvd</Filename>
-        <Type>Keil.ARM_Compiler.1.7.2</Type>
+        <Filename>C:\PACK\ARM\CMSIS\6.0.0\CMSIS\Driver\VIO\cmsis_vio.scvd</Filename>
+        <Type>ARM::CMSIS@6.0.0</Type>
         <SubType>1</SubType>
       </ScvdPack>
       <Tracepoint>
@@ -374,6 +374,30 @@
   </Group>
 
   <Group>
+    <GroupName>::CMSIS-Compiler</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>1</RteFlg>
+  </Group>
+
+  <Group>
+    <GroupName>::CMSIS-View</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>1</RteFlg>
+  </Group>
+
+  <Group>
+    <GroupName>::Device</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>1</RteFlg>
+  </Group>
+
+  <Group>
     <GroupName>::Board Support</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
@@ -391,22 +415,6 @@
 
   <Group>
     <GroupName>::CMSIS Driver</GroupName>
-    <tvExp>0</tvExp>
-    <tvExpOptDlg>0</tvExpOptDlg>
-    <cbSel>0</cbSel>
-    <RteFlg>1</RteFlg>
-  </Group>
-
-  <Group>
-    <GroupName>::Compiler</GroupName>
-    <tvExp>0</tvExp>
-    <tvExpOptDlg>0</tvExpOptDlg>
-    <cbSel>0</cbSel>
-    <RteFlg>1</RteFlg>
-  </Group>
-
-  <Group>
-    <GroupName>::Device</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/Projects/Platform/Platform.uvprojx
+++ b/Projects/Platform/Platform.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>B-U585I-IOT02A</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6210000::V6.21::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32U585AIIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32U5xx_DFP.2.1.0</PackID>
+          <PackID>Keil.STM32U5xx_DFP.2.2.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00040000) IRAM2(0x20040000,0x00080000) IROM(0x08000000,0x00200000) CPUTYPE("Cortex-M33") FPU3(SFPU) DSP TZ CLOCK(12000000) ESEL ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -452,6 +452,15 @@
           </Files>
         </Group>
         <Group>
+          <GroupName>::CMSIS-Compiler</GroupName>
+        </Group>
+        <Group>
+          <GroupName>::CMSIS-View</GroupName>
+        </Group>
+        <Group>
+          <GroupName>::Device</GroupName>
+        </Group>
+        <Group>
           <GroupName>::Board Support</GroupName>
         </Group>
         <Group>
@@ -459,12 +468,6 @@
         </Group>
         <Group>
           <GroupName>::CMSIS Driver</GroupName>
-        </Group>
-        <Group>
-          <GroupName>::Compiler</GroupName>
-        </Group>
-        <Group>
-          <GroupName>::Device</GroupName>
         </Group>
       </Groups>
     </Target>
@@ -480,7 +483,7 @@
     </gpdscs>
     <boards>
       <board Bname="B-U585I-IOT02A" Bvendor="STMicroelectronics" Bversion="Rev.C">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.1" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
@@ -488,367 +491,409 @@
     </boards>
     <apis>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="SPI" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
       <api Capiversion="2.4.0" Cclass="CMSIS Driver" Cgroup="USART" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
       <api Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
-      <api Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="5.7.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" exclusive="0">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
-      <api Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
+      <api Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDERR" condition="CortexDevice" exclusive="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDIN" condition="CortexDevice" exclusive="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDOUT" condition="CortexDevice" exclusive="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </api>
+      <api Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" exclusive="1">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
       <api Capiversion="1.1.0" Cclass="Device" Cgroup="STM32Cube Framework" condition="STM32U5" exclusive="1">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.2" url="https://www.keil.com/pack/" vendor="Keil" version="2.0.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </api>
     </apis>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Cclass="CMSIS-Compiler" Cgroup="CORE" Cvendor="ARM" Cversion="1.0.0" condition="ARMCC CortexDevice">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5">
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDERR" Csub="Custom" Cvendor="ARM" Cversion="1.0.0" condition="CORE" custom="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDIN" Csub="Custom" Cvendor="ARM" Cversion="1.0.0" condition="CORE" custom="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="I/O" Csub="STDERR" Cvariant="User" Cvendor="Keil" Cversion="1.2.0" condition="ARMCC Cortex-M">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS-Compiler" Cgroup="STDOUT" Csub="Custom" Cvendor="ARM" Cversion="1.0.0" condition="CORE" custom="1">
+        <package name="CMSIS-Compiler" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="2.0.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="I/O" Csub="STDIN" Cvariant="User" Cvendor="Keil" Cversion="1.2.0" condition="ARMCC Cortex-M">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder">
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.0.1"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="I/O" Csub="STDOUT" Cvariant="User" Cvendor="Keil" Cversion="1.2.0" condition="ARMCC Cortex-M">
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="6.0.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </component>
+      <component Capiversion="1.0.1" Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Cvendor="ARM" Cversion="1.0.5" condition="OS Tick SysTick">
+        <package name="CMSIS" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="ARM" version="6.0.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </component>
+      <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5">
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="HTS221" Cvendor="Keil" Cversion="5.3.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="IIS2MDC" Cvendor="Keil" Cversion="1.1.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="ISM330DHCX" Cvendor="Keil" Cversion="1.1.3" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="LPS22HH" Cvendor="Keil" Cversion="1.2.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="TCPP0203" Cvendor="Keil" Cversion="1.2.2" condition="STM32U585">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="BUS" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP BUS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Environmental Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP ENV SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Motion Sensors" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP MOTION SENSORS">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="USB PD" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP USB PD">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="SPI" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver SPI">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Capiversion="2.1.0" Cclass="CMSIS Driver" Cgroup="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS_Driver USART">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.0.0" condition="STM32U5 CMSIS_Driver USBD">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Capiversion="2.3.0" Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Full-speed" Cvendor="Keil" Cversion="1.1.0" condition="STM32U5 CMSIS_Driver USBD">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Capiversion="0.1.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="1.2.0" condition="B-U585I-IOT02A VIO">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+      <component Capiversion="1.0.0" Cclass="CMSIS Driver" Cgroup="VIO" Csub="Board" Cvariant="B-U585I-IOT02A" Cvendor="Keil" Cversion="2.0.0" condition="B-U585I-IOT02A VIO">
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
       <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080">
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube Framework" Csub="STM32CubeMX" Cvendor="Keil" Cversion="2.0.0" condition="STCubeMX" doc="C:/PACK/Keil/STM32U5xx_DFP/2.2.0/MDK/CubeMX/Documentation/cubemx.html" generated="1" generator="STM32CubeMX" selectable="1">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ADC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Cortex" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="DMA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="EXTI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Flash" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="HCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="I2C" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="ICACHE" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="IRDA" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA DLYB">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="MDF" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="OSPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA DLYB">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PCD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL GPIO Flash">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL GPIO Flash">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RNG" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="RTC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="SPI" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="Smartcard" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 HAL DMA">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="UART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL Common">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube HAL" Csub="USART" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 HAL DMA">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="Common" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL Common">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="DLYB" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="GPIO" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="PWR" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 LL">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="RCC" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UCPD" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 LL">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
-      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS">
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+      <component Cclass="Device" Cgroup="STM32Cube LL" Csub="UTILS" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </component>
+      <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS">
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </component>
     </components>
     <files>
-      <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.1">
+      <file attr="config" category="header" name="Drivers\Config\b_u585i_iot02a_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\b_u585i_iot02a_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Drivers" Csub="Basic I/O" Cvendor="Keil" Cversion="1.1.0" condition="B-U585I-IOT02A BSP"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
@@ -856,23 +901,31 @@
       <file attr="config" category="header" name="Drivers\Config\mx_wifi_conf.h" version="1.0.0">
         <instance index="0">RTE\Board_Support\STM32U585AIIx\mx_wifi_conf.h</instance>
         <component Cbundle="B-U585I-IOT02A" Cclass="Board Support" Cgroup="Components" Csub="EMW3080" Cvendor="Keil" Cversion="2.1.12" condition="B-U585I-IOT02A BSP EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" name="CMSIS\RTOS2\RTX\Config\RTX_Config.c" version="5.1.1">
+      <file attr="config" category="header" name="EventRecorder\Config\EventRecorderConf.h" version="1.1.0">
+        <instance index="0">RTE\CMSIS-View\EventRecorderConf.h</instance>
+        <component Cclass="CMSIS-View" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="ARM" Cversion="1.5.3" condition="EventRecorder"/>
+        <package name="CMSIS-View" schemaVersion="1.7.25" url="https://www.keil.com/pack/" vendor="ARM" version="1.1.0"/>
+        <targetInfos>
+          <targetInfo name="B-U585I-IOT02A"/>
+        </targetInfos>
+      </file>
+      <file attr="config" category="source" name="Config\RTX_Config.c" version="5.2.0">
         <instance index="0">RTE\CMSIS\RTX_Config.c</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
-      <file attr="config" category="header" name="CMSIS\RTOS2\RTX\Config\RTX_Config.h" version="5.5.2">
+      <file attr="config" category="header" name="Config\RTX_Config.h" version="5.6.0">
         <instance index="0">RTE\CMSIS\RTX_Config.h</instance>
-        <component Capiversion="2.1.3" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.5.4" condition="RTOS2 RTX5"/>
-        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
+        <component Capiversion="2.3.0" Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM" Cversion="5.8.0" condition="RTX5"/>
+        <package name="CMSIS-RTX" schemaVersion="1.7.27" url="https://www.keil.com/pack/" vendor="ARM" version="5.8.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
@@ -880,39 +933,31 @@
       <file attr="config" category="header" name="CMSIS\Driver\Config\WiFi_EMW3080_Config.h" version="1.0.0">
         <instance index="0">RTE\CMSIS_Driver\STM32U585AIIx\WiFi_EMW3080_Config.h</instance>
         <component Capiversion="1.1.0" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="EMW3080" Cvariant="SPI" Cvendor="Keil" Cversion="1.0.0" condition="B-U585I-IOT02A WIFI EMW3080"/>
-        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.7" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
-        <targetInfos>
-          <targetInfo name="B-U585I-IOT02A"/>
-        </targetInfos>
-      </file>
-      <file attr="config" category="header" name="Config\EventRecorderConf.h" version="1.1.0">
-        <instance index="0">RTE\Compiler\EventRecorderConf.h</instance>
-        <component Cbundle="ARM Compiler" Cclass="Compiler" Cgroup="Event Recorder" Cvariant="DAP" Cvendor="Keil" Cversion="1.5.1" condition="Cortex-M Device"/>
-        <package name="ARM_Compiler" schemaVersion="1.7.7" url="https://www.keil.com/pack/" vendor="Keil" version="1.7.2"/>
+        <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.28" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.1.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
       <file attr="config" category="source" condition="STM32U585 ARMCC" name="MDK\Device\Source\arm\startup_stm32u585xx.s" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\startup_stm32u585xx.s</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
       <file attr="config" category="linkerScript" condition="STM32U585 noTZ ARMCC" name="MDK\Device\Source\arm\linker\stm32u585xx_flash.sct" version="2.0.0">
         <instance index="0">RTE\Device\STM32U585AIIx\stm32u585xx_flash.sct</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </file>
-      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.2.0">
+      <file attr="config" category="source" condition="noTZ" name="Drivers\CMSIS\Device\ST\STM32U5xx\Source\Templates\system_stm32u5xx.c" version="1.3.0">
         <instance index="0">RTE\Device\STM32U585AIIx\system_stm32u5xx.c</instance>
-        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.2.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
-        <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0"/>
+        <component Cclass="Device" Cgroup="Startup" Cvariant="Source ASM" Cvendor="Keil" Cversion="1.3.0" condition="STM32U5 CMSIS" isDefaultVariant="1"/>
+        <package name="STM32U5xx_DFP" schemaVersion="1.7.28" url="https://www.keil.com/pack/" vendor="Keil" version="2.2.0"/>
         <targetInfos>
           <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
@@ -990,11 +1035,6 @@
         <LayAsnLayerName>RTOS</LayAsnLayerName>
       </LayAsnItem>
       <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil::Device:STM32Cube Framework:STM32CubeMX</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
         <LayAsnType>2</LayAsnType>
         <LayAsnName>.\Board\B-U585I-IOT02A\STM32CubeMX\STM32CubeMX.pdf</LayAsnName>
         <LayAsnLayerName>Board</LayAsnLayerName>
@@ -1036,112 +1076,7 @@
       </LayAsnItem>
       <LayAsnItem>
         <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.#Bundle#::Compiler:Event Recorder</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.#Bundle#::Compiler:I/O:STDERR</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.#Bundle#::Compiler:I/O:STDIN</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.#Bundle#::Compiler:I/O:STDOUT</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Drivers:Basic I/O</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Drivers:BUS</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Drivers:Environmental Sensors</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Drivers:Motion Sensors</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Drivers:USB PD</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Components:EMW3080</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Components:HTS221</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Components:IIS2MDC</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Components:ISM330DHCX</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Components:LPS22HH</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil.B-U585I-IOT02A::Board Support:Components:TCPP0203</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
         <LayAsnName>ARM::CMSIS:CORE</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil::Device:Startup</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil::CMSIS Driver:WiFi:EMW3080</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil::CMSIS Driver:VIO:Board</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil::CMSIS Driver:USART</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil::CMSIS Driver:SPI</LayAsnName>
-        <LayAsnLayerName>Board</LayAsnLayerName>
-      </LayAsnItem>
-      <LayAsnItem>
-        <LayAsnType>1</LayAsnType>
-        <LayAsnName>Keil::CMSIS Driver:USB Device:Full-speed</LayAsnName>
         <LayAsnLayerName>Board</LayAsnLayerName>
       </LayAsnItem>
       <LayAsnItem>
@@ -1288,6 +1223,71 @@
         <LayAsnType>1</LayAsnType>
         <LayAsnName>Keil::Device:STM32Cube LL:UTILS</LayAsnName>
         <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>ARM::CMSIS-View:Event Recorder</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>ARM::CMSIS-Compiler:CORE</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>ARM::CMSIS-Compiler:STDERR:Custom</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>ARM::CMSIS-Compiler:STDIN:Custom</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>ARM::CMSIS-Compiler:STDOUT:Custom</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>Keil::Device:Startup</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>Keil::Device:STM32Cube Framework:STM32CubeMX</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>Keil::CMSIS Driver:SPI</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>Keil::CMSIS Driver:USART</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>Keil::CMSIS Driver:USB Device:Full-speed</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>Keil::CMSIS Driver:VIO:Board</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>Keil::CMSIS Driver:WiFi:EMW3080</LayAsnName>
+        <LayAsnLayerName>Board</LayAsnLayerName>
+      </LayAsnItem>
+      <LayAsnItem>
+        <LayAsnType>1</LayAsnType>
+        <LayAsnName>ARM::CMSIS:OS Tick:SysTick</LayAsnName>
+        <LayAsnLayerName>RTOS</LayAsnLayerName>
       </LayAsnItem>
     </LayAssign>
   </LayerInfo>

--- a/Projects/Platform/README.md
+++ b/Projects/Platform/README.md
@@ -7,17 +7,17 @@ and is a CMSIS-RTOS2 based software template that can be further expanded.
 RTOS: Keil RTX5 Real-Time Operating System
 ------------------------------------------
 
-The real-time operating system [Keil RTX5](https://arm-software.github.io/CMSIS_5/RTOS2/html/rtx5_impl.html) implements the resource management. 
+The real-time operating system [Keil RTX5](https://arm-software.github.io/CMSIS-RTX/latest/index.html) implements the resource management. 
 
 It is configured with the following settings:
 
-- [Global Dynamic Memory size](https://arm-software.github.io/CMSIS_5/RTOS2/html/config_rtx5.html#systemConfig): 32768 bytes
-- [Default Thread Stack size](https://arm-software.github.io/CMSIS_5/RTOS2/html/config_rtx5.html#threadConfig): 3072 bytes
-- [Event Recorder Configuration](https://arm-software.github.io/CMSIS_5/RTOS2/html/config_rtx5.html#evtrecConfig)
-  - [Global Initialization](https://arm-software.github.io/CMSIS_5/RTOS2/html/config_rtx5.html#evtrecConfigGlobIni): 1
+- [Global Dynamic Memory size](https://arm-software.github.io/CMSIS-RTX/latest/config_rtx5.html#systemConfig): 32768 bytes
+- [Default Thread Stack size](https://arm-software.github.io/CMSIS-RTX/latest/config_rtx5.html#threadConfig): 3072 bytes
+- [Event Recorder Configuration](https://arm-software.github.io/CMSIS-RTX/latest/config_rtx5.html#evtrecConfig)
+  - [Global Initialization](https://arm-software.github.io/CMSIS-RTX/latest/config_rtx5.html#evtrecConfigGlobIni): 1
     - Start Recording: 1
 
-Refer to [Configure RTX v5](https://arm-software.github.io/CMSIS_5/RTOS2/html/config_rtx5.html) for a detailed description of all configuration options.
+Refer to [Configure RTX v5](https://arm-software.github.io/CMSIS-RTX/latest/config_rtx5.html) for a detailed description of all configuration options.
 
 Board: STMicroelectronics [B-U585I-IOT02A](https://www.st.com/en/evaluation-tools/b-u585i-iot02a.html)
 ------------------------------------------
@@ -63,6 +63,3 @@ Refer to ["Migrate STM32 Based Example Projects to Custom Hardware"](https://git
 | vioBUTTON0        | Button USER (PC13)
 | vioLED0           | LED RED (PH6)
 | vioLED1           | LED GREEN (PH7)
-| vioMotionGyro     | iNEMO 3D gyroscope (ISM330DLC)
-| vioMotionAccelero | iNEMO 3D accelerometer (ISM330DLC)
-| vioMotionMagneto  | High accuracy 3-axis magnetometer (IIS2MDC)

--- a/Projects/Platform/RTE/CMSIS-View/EventRecorderConf.h
+++ b/Projects/Platform/RTE/CMSIS-View/EventRecorderConf.h
@@ -1,11 +1,24 @@
-/*------------------------------------------------------------------------------
- * MDK - Component ::Event Recorder
- * Copyright (c) 2016-2018 ARM Germany GmbH. All rights reserved.
- *------------------------------------------------------------------------------
+/*
+ * Copyright (c) 2016-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Name:    EventRecorderConf.h
- * Purpose: Event Recorder Configuration
+ * Purpose: Event Recorder software component configuration options
  * Rev.:    V1.1.0
- *----------------------------------------------------------------------------*/
+ */
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 

--- a/Projects/Platform/RTE/CMSIS/RTX_Config.c
+++ b/Projects/Platform/RTE/CMSIS/RTX_Config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.1
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration
@@ -54,6 +54,9 @@ __WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
       break;
     case osRtxErrorClibMutex:
       // Standard C/C++ library mutex initialization failed
+      break;
+    case osRtxErrorSVC:
+      // Invalid SVC function called (function=object_id)
       break;
     default:
       // Reserved

--- a/Projects/Platform/RTE/CMSIS/RTX_Config.h
+++ b/Projects/Platform/RTE/CMSIS/RTX_Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.5.2
+ * $Revision:   V5.6.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -146,6 +146,20 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID    0
 #endif
  
+//   <o>Idle Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_CLASS
+#define OS_IDLE_THREAD_CLASS        0
+#endif
+ 
+//   <o>Idle Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_IDLE_THREAD_ZONE
+#define OS_IDLE_THREAD_ZONE         0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enables stack overrun check at thread switch (requires RTX source variant).
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -160,10 +174,10 @@
 #define OS_STACK_WATERMARK          0
 #endif
  
-//   <o>Processor mode for Thread execution
+//   <o>Default Processor mode for Thread execution
 //     <0=> Unprivileged mode
 //     <1=> Privileged mode
-//   <i> Default: Privileged mode
+//   <i> Default: Unprivileged mode
 #ifndef OS_PRIVILEGE_MODE
 #define OS_PRIVILEGE_MODE           1
 #endif
@@ -213,6 +227,20 @@
 //   <i> Default: 0 (not used)
 #ifndef OS_TIMER_THREAD_TZ_MOD_ID
 #define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Thread Safety Class <0-15>
+//   <i> Defines the Safety Class number.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_CLASS
+#define OS_TIMER_THREAD_CLASS       0
+#endif
+ 
+//   <o>Timer Thread Zone <0-127>
+//   <i> Defines Thread Zone.
+//   <i> Default: 0
+#ifndef OS_TIMER_THREAD_ZONE
+#define OS_TIMER_THREAD_ZONE        0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>


### PR DESCRIPTION
Synchronized BSP with CMSIS 6:
 - Updated VIO components
 - Updated Blinky&Platform
 - Updated Middleware examples (using version 7.17.0)